### PR TITLE
docs: パッケージ名とCLIオプションの記載を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ search-docsは、クライアント・サーバ構成で実装されています
 
 ### コンポーネント
 
-- **Server**: プロジェクト毎に起動される文書管理・検索サーバ
-- **Client Library**: サーバと通信するTypeScriptクライアント
-- **CLI Tool**: コマンドラインインターフェイス
-- **MCP Server**: Claude Code統合用のMCPサーバ
+- **Server** (`@search-docs/server`): プロジェクト毎に起動される文書管理・検索サーバ
+- **Client Library** (`@search-docs/client`): サーバと通信するTypeScriptクライアント
+- **CLI Tool** (`@search-docs/cli`): コマンドラインインターフェイス
+- **MCP Server** (`@search-docs/mcp-server`): Claude Code統合用のMCPサーバ
+- **DB Engine** (`@search-docs/db-engine`): LanceDB操作のPythonラッパー
+- **Storage** (`@search-docs/storage`): 文書の永続化層
+- **Types** (`@search-docs/types`): 共通の型定義
 
 詳細なアーキテクチャ情報については、以下のドキュメントを参照してください：
 - [クライアント・サーバアーキテクチャ](docs/client-server-architecture.md)
@@ -65,7 +68,13 @@ pnpm build
 ### グローバルインストール（本番利用）
 
 ```bash
-npm install -g search-docs
+# グローバルインストール
+npm install -g @search-docs/cli
+
+# またはnpxで直接実行（インストール不要）
+npx @search-docs/cli config init
+npx @search-docs/cli server start
+npx @search-docs/cli search "検索クエリ"
 ```
 
 ### GPU対応（オプション）
@@ -161,14 +170,30 @@ search-docs search "検索クエリ" --limit 20
 
 ### Claude Code統合
 
-```bash
-# MCP Serverとして追加
-claude mcp add search-docs -- search-docs mcp-server --project $(pwd)
+MCP Serverとして利用する場合は、Claude Codeの設定ファイルに以下を追加します：
+
+```json
+{
+  "mcpServers": {
+    "search-docs": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/search-docs/packages/mcp-server/dist/server.js",
+        "--project-dir",
+        "${workspaceFolder}"
+      ]
+    }
+  }
+}
 ```
+
+**注意**: `/absolute/path/to/search-docs/` は実際のパスに置き換えてください。
+
+詳細は [MCP統合ガイド](docs/mcp-integration.md) を参照してください。
 
 ### 設定ファイル
 
-プロジェクトルートに `.search-docs/config.json` を配置：
+プロジェクトルートに `.search-docs.json` を配置：
 
 ```json
 {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,6 +2,22 @@
 
 search-docs CLIツールの完全なコマンドリファレンスです。
 
+## インストールと使用方法
+
+### グローバルインストール
+
+```bash
+npm install -g @search-docs/cli
+```
+
+### npxで直接実行（インストール不要）
+
+```bash
+npx @search-docs/cli <command>
+```
+
+**注意**: 以下のコマンド例では `search-docs` を使用していますが、npxで実行する場合は `npx @search-docs/cli` に置き換えてください。
+
 ## 目次
 
 - [グローバルオプション](#グローバルオプション)
@@ -21,10 +37,21 @@ search-docs [options] [command]
 
 ### オプション
 
-| オプション | 説明 |
-|-----------|------|
-| `-V, --version` | バージョン番号を表示 |
-| `-h, --help` | ヘルプを表示 |
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `-v, --version` | バージョン情報を表示 | - |
+| `-c, --config <path>` | 設定ファイルのパス | `.search-docs.json` |
+| `-h, --help` | ヘルプを表示 | - |
+
+**注意**: `--config`オプションはグローバルオプションのため、コマンドの前に指定します。
+
+```bash
+# 正しい使い方
+search-docs --config ./custom-config.json server start
+
+# 誤った使い方
+search-docs server start --config ./custom-config.json
+```
 
 ### 使用例
 
@@ -55,8 +82,7 @@ search-docs server start [options]
 
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
-| `--config <path>` | 設定ファイルのパス | `.search-docs.json` |
-| `--port <port>` | ポート番号 | `24280` |
+| `--port <port>` | ポート番号 | 設定ファイルのポート |
 | `--foreground, -f` | フォアグラウンドで起動（開発時） | `false` |
 | `--log <path>` | ログファイルのパス | なし |
 
@@ -75,8 +101,8 @@ search-docs server start --port 24281
 # ログファイルを指定して起動
 search-docs server start --log .search-docs/server.log
 
-# カスタム設定ファイルを使用
-search-docs server start --config ./custom-config.json
+# カスタム設定ファイルを使用（グローバルオプション）
+search-docs --config ./custom-config.json server start
 ```
 
 #### 動作
@@ -100,14 +126,12 @@ search-docs server start --config ./custom-config.json
 サーバを停止します。
 
 ```bash
-search-docs server stop [options]
+search-docs server stop
 ```
 
 #### オプション
 
-| オプション | 説明 | デフォルト |
-|-----------|------|-----------|
-| `--config <path>` | 設定ファイルのパス | `.search-docs.json` |
+なし（グローバルオプション`--config`は使用可能）
 
 #### 使用例
 
@@ -115,8 +139,8 @@ search-docs server stop [options]
 # サーバを停止
 search-docs server stop
 
-# カスタム設定ファイルを指定
-search-docs server stop --config ./custom-config.json
+# カスタム設定ファイルを指定（グローバルオプション）
+search-docs --config ./custom-config.json server stop
 ```
 
 #### 動作
@@ -136,20 +160,21 @@ search-docs server stop --config ./custom-config.json
 サーバの状態を確認します。
 
 ```bash
-search-docs server status [options]
+search-docs server status
 ```
 
 #### オプション
 
-| オプション | 説明 | デフォルト |
-|-----------|------|-----------|
-| `--config <path>` | 設定ファイルのパス | `.search-docs.json` |
+なし（グローバルオプション`--config`は使用可能）
 
 #### 使用例
 
 ```bash
 # サーバの状態を確認
 search-docs server status
+
+# カスタム設定ファイルを指定（グローバルオプション）
+search-docs --config ./custom-config.json server status
 ```
 
 #### 出力例
@@ -184,13 +209,21 @@ search-docs server restart [options]
 
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
-| `--config <path>` | 設定ファイルのパス | `.search-docs.json` |
+| `--port <port>` | ポート番号 | 設定ファイルのポート |
+| `--foreground, -f` | フォアグラウンドで起動（開発時） | `false` |
+| `--log <path>` | ログファイルのパス | なし |
 
 #### 使用例
 
 ```bash
-# サーバを再起動
+# サーバを再起動（バックグラウンド）
 search-docs server restart
+
+# フォアグラウンドで再起動
+search-docs server restart --foreground
+
+# カスタムポートで再起動
+search-docs server restart --port 24281
 ```
 
 #### 動作
@@ -201,7 +234,6 @@ search-docs server restart
 
 #### 注意事項
 
-- 常にバックグラウンドモードで起動されます
 - 設定ファイルを変更した場合は再起動が必要です
 
 ## search コマンド
@@ -223,10 +255,10 @@ search-docs search <query> [options]
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
 | `--limit <n>` | 最大結果数 | `10` |
-| `--depth <depths...>` | 深度フィルタ（複数指定可） | すべて |
+| `--depth <depth>` | 最大深度（0=文書全体のみ、1=章まで、2=節まで、3=項まで） | すべて |
 | `--format <format>` | 出力形式（text, json） | `text` |
 | `--clean-only` | Dirtyセクションを除外 | `false` |
-| `--server <url>` | サーバURL | `http://localhost:24280` |
+| `--server <url>` | サーバURL | 設定ファイルのURL |
 
 ### 使用例
 
@@ -237,8 +269,11 @@ search-docs search "Vector検索"
 # 結果数を指定
 search-docs search "Vector検索" --limit 20
 
-# depth 1と2のみ検索
-search-docs search "Vector検索" --depth 1 2
+# depth 1まで検索（文書全体と章）
+search-docs search "Vector検索" --depth 1
+
+# depth 2まで検索（文書全体、章、節）
+search-docs search "Vector検索" --depth 2
 
 # JSON形式で出力
 search-docs search "Vector検索" --format json

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -32,11 +32,15 @@ Model Context Protocol (MCP)は、AI アシスタントが外部ツールやデ�
 
 1. **search-docsサーバが起動していること**
    ```bash
+   # グローバルインストールの場合
    search-docs server start
+
+   # またはnpxの場合
+   npx @search-docs/cli server start
    ```
 
 2. **プロジェクトに設定ファイルがあること**
-   - `.search-docs.json` または `.search-docs/config.json`
+   - `.search-docs.json` (推奨) または `search-docs.json`
 
 ### 方法1: プロジェクトスコープ設定（推奨）
 
@@ -104,12 +108,23 @@ Claude Codeのグローバル設定ファイルに追加します。
 }
 ```
 
-**注意**: グローバルインストール（`npm install -g search-docs`）が必要です。
+**注意**: グローバルインストール（`npm install -g @search-docs/mcp-server`）が必要です。
 
-### 方法3: Claude Code コマンドで追加
+または、npxを使用する場合：
 
-```bash
-claude mcp add search-docs -- search-docs mcp-server --project-dir $(pwd)
+```json
+{
+  "mcpServers": {
+    "search-docs": {
+      "command": "npx",
+      "args": [
+        "@search-docs/mcp-server",
+        "--project-dir",
+        "${workspaceFolder}"
+      ]
+    }
+  }
+}
 ```
 
 ## 利用可能なツール

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -39,7 +39,15 @@ pnpm build
 ### グローバルインストールの場合
 
 ```bash
-npm install -g search-docs
+npm install -g @search-docs/cli
+```
+
+### npxで直接実行する場合（インストール不要）
+
+```bash
+# インストール不要で直接使用可能
+npx @search-docs/cli config init
+npx @search-docs/cli server start
 ```
 
 ## ステップ2: テストプロジェクトを作成
@@ -127,10 +135,14 @@ search-docsは以下の手順で使用します：
 node /path/to/search-docs/packages/cli/dist/index.js server start
 ```
 
-### グローバルインストールの場合
+### グローバルインストールまたはnpxの場合
 
 ```bash
+# グローバルインストールした場合
 search-docs server start
+
+# npxで実行する場合
+npx @search-docs/cli server start
 ```
 
 **注意**: v1.0.1以降、サーバはデフォルトでバックグラウンドで起動します。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,7 +43,12 @@ pnpm build
 #### グローバルインストール（本番利用）
 
 ```bash
-npm install -g search-docs
+# グローバルインストール
+npm install -g @search-docs/cli
+
+# またはnpxで直接実行（インストール不要）
+npx @search-docs/cli config init
+npx @search-docs/cli server start
 ```
 
 ### 設定ファイルの作成


### PR DESCRIPTION
## 概要

ユーザー向けドキュメントのパッケージ名とCLIオプションの記載を実装に合わせて修正しました。

## 主な変更内容

### 1. パッケージ名の修正
- ❌ `npm install -g search-docs` 
- ✅ `npm install -g @search-docs/cli`
- モノレポの正式なパッケージ名（`@search-docs/*`）に統一
- 全7パッケージ（cli, server, client, mcp-server, db-engine, storage, types）を明記

### 2. npxでの実行方法を追加
- インストール不要で試せる方法を追加
- `npx @search-docs/cli <command>` での実行例を記載
- ユーザビリティの向上

### 3. CLIオプションの修正（cli-reference.md）

**実装との不整合を修正:**
- ✅ `--config`オプションをグローバルオプションとして正しく記載
- ✅ `--depth`オプションを単一値に修正（`<depths...>` → `<depth>`）
- ✅ `server restart`コマンドのオプション（`--port`, `--foreground`, `--log`）を追加

**詳細:**
- グローバルオプションセクションに`-c, --config <path>`を追加
- 正しい使用方法を明記（`search-docs --config <path> [command]`）
- 各サブコマンドから誤った`--config`の記載を削除

### 4. MCP Server統合の修正
- ❌ 誤った`claude mcp add`コマンドを削除
- ✅ 正しいJSON設定形式に変更
- ✅ npxでの実行パターンを追加
- ✅ パッケージ名を`@search-docs/mcp-server`に修正

### 5. 設定ファイルパスの修正
- ❌ `.search-docs/config.json`
- ✅ `.search-docs.json`
- 実際のファイル構造に合わせて修正

## 影響範囲

- [x] README.md - メインドキュメント
- [x] docs/quick-start.md - クイックスタートガイド
- [x] docs/user-guide.md - ユーザーガイド
- [x] docs/cli-reference.md - CLIリファレンス
- [x] docs/mcp-integration.md - MCP統合ガイド

## テスト

- [x] `node packages/cli/dist/index.js --help` で実装を確認
- [x] 各コマンドのヘルプ出力と記載内容の整合性を確認
- [x] 実際の設定ファイル（`.search-docs.json`）の存在を確認

## 備考

この修正により、ユーザーがドキュメント通りにコマンドを実行した際に、存在しないオプションエラーが発生しなくなります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)