### PR TITLE
fix(ci): remove pnpm version specification from workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -17,8 +17,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,8 +21,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 問題

GitHub Actionsでpnpmのバージョン指定が重複していました:
- ワークフロー: `version: 9`
- package.json: `packageManager: pnpm@9.14.4`

## 修正

ワークフローの`version`指定を削除し、package.jsonの`packageManager`を使用するようにしました。

```
Error: Multiple versions of pnpm specified
```

このエラーが解消されます。