### PR TITLE
fix(ci): add uv setup and build step to release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -23,8 +23,15 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
 
       - name: Apply changesets
         run: pnpm changeset version


### PR DESCRIPTION
## 問題

release-prepareワークフローで2つのエラーが発生:

1. `uv: not found` - postinstallスクリプトでuvコマンドが必要
2. `WARN Failed to create bin` - CLIのdistディレクトリが存在しない

## 修正

1. `astral-sh/setup-uv@v5` アクションを追加
2. `pnpm build` ステップを追加（changeset version前に実行）

これにより:
- uvが利用可能になり、postinstallスクリプト(`uv sync`)が成功
- CLIがビルドされ、binリンクが正しく作成される