### PR TITLE
fix(db-engine): Python 3.14未満に制限（PyTorch互換性のため）

### DIFF
--- a/.changeset/fix-python-version-constraint.md
+++ b/.changeset/fix-python-version-constraint.md
@@ -1,0 +1,9 @@
+---
+"@search-docs/db-engine": patch
+---
+
+Python 3.14未満に制限（PyTorch torch.compile互換性のため）
+
+PyTorch 2.9.1のtorch.compileがPython 3.14をサポートしていないため、requires-pythonを">=3.11,<3.14"に変更しました。この制限により、ModernBERTベースのRuri埋め込みモデルが正しく動作します。
+
+PyTorch 2.10以降でPython 3.14サポートが安定したら、この制限を解除する予定です。

--- a/packages/db-engine/pyproject.toml
+++ b/packages/db-engine/pyproject.toml
@@ -2,7 +2,7 @@
 name = "search-docs-db-engine"
 version = "0.1.0"
 description = "search-docs LanceDB Vector検索エンジン"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "lancedb>=0.5.0",
     "pyarrow>=14.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "search-docs"
 version = "0.1.0"
 description = "🐕️ ローカル文書検索システム - Markdown文書に対するVector検索機能を提供"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "lancedb>=0.5.0",
     "pyarrow>=14.0.0",


### PR DESCRIPTION
## 概要

PyTorch 2.9.1のtorch.compileがPython 3.14をサポートしていないため、Python バージョンを `>=3.11,<3.14` に制限しました。

## 問題

- ModernBERTモデル（Ruri埋め込みモデルのベース）が `@torch.compile(dynamic=True)` decoratorを使用
- PyTorch 2.9.1では `sys.version_info >= (3, 14)` でエラーが発生
- グローバルインストール時にPython 3.14環境が構築され、ModernBertModelのインポートに失敗

## 調査結果

- GitHubのmainブランチでは制限が `>= (3, 15)` に変更されている
- しかし、PyPI上のwheel（2.9.1およびnightly 2.10.0.dev）にはまだ反映されていない
- PyPI上では"Python 3.14サポート"と記載されているが、実際のコードには制限が残っている

## 変更内容

- `packages/db-engine/pyproject.toml`: `requires-python = ">=3.11,<3.14"`
- `pyproject.toml`: `requires-python = ">=3.11,<3.14"`
- changesetファイル追加

## 影響

- Python 3.11-3.13で動作
- グローバルインストール時に正しいPython環境が構築される
- ModernBertModelが正常にインポート可能

## テスト結果

```bash
# Python 3.11.13環境で成功
✓ Success: ModernBertModel imported successfully with Python 3.11.13
```

## 将来の対応

PyTorch 2.10以降でPython 3.14サポートが安定したら、この制限を解除する予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)