### PR TITLE
chore: changesetを追加 (get_outlineツール)

### DIFF
--- a/.changeset/add-get-outline-tool.md
+++ b/.changeset/add-get-outline-tool.md
@@ -1,0 +1,14 @@
+---
+"@search-docs/types": patch
+"@search-docs/server": patch
+"@search-docs/client": patch
+"@search-docs/mcp-server": patch
+"@search-docs/db-engine": patch
+"@search-docs/cli": patch
+---
+
+文書構造を表示するget_outlineツールを追加し、ESLintエラーを修正しました。
+
+- 新機能: get_outlineツールで文書のアウトライン（セクション番号・行数・トークン数）を取得
+- path/sectionId両対応、関連プロジェクトサポート
+- ESLintエラー修正: Python型インターフェースの追加、未使用変数の修正


### PR DESCRIPTION
## 概要

PR #13でマージされたget_outlineツールのchangesetを追加します。

## 変更内容

- `.changeset/add-get-outline-tool.md` を追加
- patchバージョンアップ対象パッケージ：
  - @search-docs/types
  - @search-docs/server
  - @search-docs/client
  - @search-docs/mcp-server
  - @search-docs/db-engine
  - @search-docs/cli

## 関連

- #13
- #12