### PR TITLE
fix: H4以降の見出し（####, #####, ######）がスキップされるバグを修正

### DIFF
--- a/packages/server/src/splitter/__tests__/markdown-splitter.test.ts
+++ b/packages/server/src/splitter/__tests__/markdown-splitter.test.ts
@@ -198,11 +198,12 @@ H5の内容`;
       expect(sections).toHaveLength(2);
       expect(sections[0].depth).toBe(0); // 文書ルート
       expect(sections[1].heading).toBe('H2 Section');
-      // H4, H5の内容が含まれている（見出しテキストと内容）
+      // H4, H5の見出しと内容が含まれている
       expect(sections[1].content).toContain('H2の内容');
+      expect(sections[1].content).toContain('#### H4 Section'); // 見出しも保持される
       expect(sections[1].content).toContain('H4の内容');
+      expect(sections[1].content).toContain('##### H5 Section'); // 見出しも保持される
       expect(sections[1].content).toContain('H5の内容');
-      // Note: markedがH4/H5をHTML化する可能性があるため、見出し文字列のチェックは行わない
     });
   });
 

--- a/packages/server/src/splitter/markdown-splitter.ts
+++ b/packages/server/src/splitter/markdown-splitter.ts
@@ -119,8 +119,22 @@ export class MarkdownSplitter {
             // 親がない場合は直接追加
             nodes.push(currentDepth3);
           }
+        } else {
+          // H4以降（#### ##### ######）は独立したセクションとせず、
+          // 親ノード（最も深いH3/H2/H1）のコンテンツの一部として保存
+          const text = this.tokenToMarkdown(token);
+          const targetNode = currentDepth3 || currentDepth2 || currentDepth1;
+
+          if (text.trim()) {
+            if (targetNode) {
+              targetNode.content.push(text);
+              targetNode.endLine = tokenEndLine;
+            } else {
+              // 見出しのない前文として扱う
+              contentBuffer.push(text);
+            }
+          }
         }
-        // H4以降は無視（親セクションに含める）
       } else {
         // コンテンツを現在のノードに追加
         const text = this.tokenToMarkdown(token);


### PR DESCRIPTION
## 問題

MarkdownSplitterがH4以降（`####`, `#####`, `######`）の見出しを完全にスキップしていました。

## 再現手順

```markdown
### H3 見出し

#### H4 見出し

##### H5 見出し

本文テキスト
```

上記のMarkdownをインデックスすると、H4とH5の見出しが完全に欠落していました。

## 修正内容

- H4以降の見出しを親ノード（最も深いH3/H2/H1）のコンテンツの一部として保存するように修正
- Markdownの見出し記法（`#### タイトル`）はそのまま保持される
- 独立したセクションとしては作成されない（既存の仕様通り）

## テスト

- 既存のテストケース「H4以降の見出しは親セクションに含める」を強化
- H4/H5の見出し記法が保持されることを検証
- 全25テストケースが通過

## 影響範囲

H4以降の見出しを含む文書で、該当部分が検索可能になります。

Fixes #18