### PR TITLE
fix: totalDocumentsが0になるバグを修正（pylance依存を追加）

### DIFF
--- a/.changeset/fix-total-documents-zero.md
+++ b/.changeset/fix-total-documents-zero.md
@@ -1,0 +1,7 @@
+---
+'@search-docs/db-engine': patch
+---
+
+totalDocumentsが0になるバグを修正
+
+get_stats()関数でtable.to_lance()を使用していましたが、pylanceパッケージへの依存が必要でした。pyproject.tomlにpylance>=0.9.0を追加することで、totalDocumentsを正しく取得できるようになりました。

--- a/packages/db-engine/pyproject.toml
+++ b/packages/db-engine/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pytest>=7.0.0",
     "psutil>=5.9.0",
     "duckdb>=0.9.0",
+    "pylance>=0.9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 問題

`index status`で`totalDocuments`が常に0になります。

```
Index:
  Documents:  0
  Sections:   3432
  Dirty:      0
```

## 原因

`packages/db-engine/src/python/worker.py`の`get_stats()`関数（1001行目）で`table.to_lance()`を呼び出していますが、これには`pylance`パッケージが必要です。

`pylance`が`pyproject.toml`の依存関係に含まれていないため、以下のエラーが発生していました：

```
Warning: Could not get unique document count: The lance library is required to use this function. Please install with `pip install pylance`.
```

## 修正内容

`packages/db-engine/pyproject.toml`に`pylance>=0.9.0`を依存関係として追加しました。

## テスト

- 全23テストが通過
- 警告メッセージが出なくなることを確認

## 影響

`index status`で正しいドキュメント数が表示されるようになります。

Fixes #23