### PR TITLE
fix: get_outline APIの問題修正とH4/H5/H6のchangeset追加

### DIFF
--- a/.changeset/fix-get-outline-issues.md
+++ b/.changeset/fix-get-outline-issues.md
@@ -1,0 +1,8 @@
+---
+"@search-docs/server": patch
+---
+
+fix: get_outline APIの3つの問題を修正
+- セクションの並び順をsection_number辞書順に修正（orderフィールドではなく階層順）
+- YAML frontmatterを除去（メタデータブロックが見出しとして扱われる問題を解消）
+- document root（depth=0）を結果から除外（常に先頭が"1"になる問題を解消）

--- a/.changeset/fix-h4-h5-h6-headers.md
+++ b/.changeset/fix-h4-h5-h6-headers.md
@@ -1,0 +1,5 @@
+---
+"@search-docs/server": patch
+---
+
+fix: H4/H5/H6見出しが保存されない問題を修正（changesetの追加漏れによる再リリース）

--- a/packages/server/src/__tests__/get-outline.test.ts
+++ b/packages/server/src/__tests__/get-outline.test.ts
@@ -173,28 +173,117 @@ describe('getOutline API', () => {
 
     const result = await server.getOutline({ path: docPath });
 
-    expect(result.items).toHaveLength(3);
+    // depth=0（document root）は除外される
+    expect(result.items).toHaveLength(2);
     expect(result.items[0]).toEqual({
-      number: '1',
-      heading: '# Title',
-      lines: 10,
-      tokens: 100,
-      id: 'section-0',
-    });
-    expect(result.items[1]).toEqual({
       number: '1.1',
       heading: '## Section 1',
       lines: 10,
       tokens: 50,
       id: 'section-1',
     });
-    expect(result.items[2]).toEqual({
+    expect(result.items[1]).toEqual({
       number: '1.2',
       heading: '## Section 2',
       lines: 5,
       tokens: 30,
       id: 'section-2',
     });
+  });
+
+  it('section_numberの辞書順でソート（複雑な階層）', async () => {
+    const docPath = 'test-complex-order.md';
+    const doc: Document = {
+      path: docPath,
+      content: '# Root\n## A\n#### A.1.1\n## A.1',
+      metadata: {
+        fileHash: createHash('sha256').update('test-complex').digest('hex'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    };
+
+    await storage.save(doc.path, doc);
+
+    // orderとsection_numberが一致しないケース
+    await dbEngine.addSections([
+      {
+        id: 'root',
+        documentPath: docPath,
+        documentHash: doc.metadata.fileHash,
+        heading: '(document root)',
+        depth: 0,
+        content: '',
+        tokenCount: 10,
+        parentId: null,
+        order: 0,
+        isDirty: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        startLine: 1,
+        endLine: 1,
+        sectionNumber: [1],
+      },
+      {
+        id: 'section-a',
+        documentPath: docPath,
+        documentHash: doc.metadata.fileHash,
+        heading: '## A',
+        depth: 1,
+        content: '## A',
+        tokenCount: 50,
+        parentId: 'root',
+        order: 1,
+        isDirty: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        startLine: 2,
+        endLine: 5,
+        sectionNumber: [1, 1],
+      },
+      {
+        id: 'section-a-1-1',
+        documentPath: docPath,
+        documentHash: doc.metadata.fileHash,
+        heading: '#### A.1.1',
+        depth: 1, // H4以降は親のcontentに含まれるが、テスト用に独立セクションとして登録
+        content: '#### A.1.1',
+        tokenCount: 30,
+        parentId: 'section-a',
+        order: 2, // order上は2番目
+        isDirty: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        startLine: 6,
+        endLine: 10,
+        sectionNumber: [1, 1, 1], // section_number上は [1, 1, 1]
+      },
+      {
+        id: 'section-a-1',
+        documentPath: docPath,
+        documentHash: doc.metadata.fileHash,
+        heading: '## A.1',
+        depth: 1,
+        content: '## A.1',
+        tokenCount: 40,
+        parentId: 'root',
+        order: 3, // order上は3番目だが、section_numberでは [1, 1, 1] より前
+        isDirty: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        startLine: 11,
+        endLine: 15,
+        sectionNumber: [1, 2], // section_number上は [1, 2]
+      },
+    ]);
+
+    const result = await server.getOutline({ path: docPath });
+
+    // section_numberの辞書順でソート: [1,1] < [1,1,1] < [1,2]
+    expect(result.items).toHaveLength(3);
+    expect(result.items[0].number).toBe('1.1'); // section-a
+    expect(result.items[1].number).toBe('1.1.1'); // section-a-1-1
+    expect(result.items[2].number).toBe('1.2'); // section-a-1
   });
 
   it('sectionId指定で特定セクション配下のアウトラインを取得', async () => {

--- a/packages/server/src/server/search-docs-server.ts
+++ b/packages/server/src/server/search-docs-server.ts
@@ -312,8 +312,24 @@ export class SearchDocsServer {
       sections = result.sections;
     }
 
-    // orderでソート
-    sections.sort((a, b) => a.order - b.order);
+    // depth=0（document root）を除外
+    sections = sections.filter(s => s.depth > 0);
+
+    // section_numberの配列を辞書順で比較してソート
+    sections.sort((a, b) => {
+      const aNum = a.sectionNumber;
+      const bNum = b.sectionNumber;
+
+      // 配列を要素ごとに比較
+      for (let i = 0; i < Math.min(aNum.length, bNum.length); i++) {
+        if (aNum[i] !== bNum[i]) {
+          return aNum[i] - bNum[i];
+        }
+      }
+
+      // 前半が同じ場合、短い方が先（例: [1, 2] < [1, 2, 1]）
+      return aNum.length - bNum.length;
+    });
 
     // OutlineItemに変換
     const items: OutlineItem[] = sections.map(section => ({

--- a/packages/server/src/splitter/__tests__/markdown-splitter.test.ts
+++ b/packages/server/src/splitter/__tests__/markdown-splitter.test.ts
@@ -360,6 +360,52 @@ Some content here`;
   });
 
   describe('Markdownの各種要素', () => {
+    it('YAML frontmatterを除去する', () => {
+      const md = `---
+title: Test Document
+author: John Doe
+date: 2025-01-01
+---
+
+# Actual Content
+
+This is the real content.`;
+
+      const sections = splitter.split(md, '/test.md', 'hash123');
+
+      // frontmatter は除去され、# Actual Content から処理される
+      expect(sections).toHaveLength(2); // depth=0 + H1
+      expect(sections[0].content).not.toContain('title:');
+      expect(sections[0].content).not.toContain('author:');
+      expect(sections[0].content).toContain('# Actual Content');
+      expect(sections[1].heading).toBe('Actual Content');
+    });
+
+    it('frontmatterがない場合は通常通り処理する', () => {
+      const md = `# Normal Content
+
+No frontmatter here.`;
+
+      const sections = splitter.split(md, '/test.md', 'hash123');
+
+      expect(sections).toHaveLength(2); // depth=0 + H1
+      expect(sections[1].heading).toBe('Normal Content');
+      expect(sections[1].content).toContain('No frontmatter here');
+    });
+
+    it('不完全なfrontmatter（閉じ---がない）は除去しない', () => {
+      const md = `---
+title: Test
+This is not closed
+
+# Content`;
+
+      const sections = splitter.split(md, '/test.md', 'hash123');
+
+      // frontmatterとして扱われないため、元のままパースされる
+      expect(sections).toHaveLength(2); // depth=0 + H1
+    });
+
     it('リストを含むコンテンツを正しく処理できる', () => {
       const md = `# Section
 - Item 1

--- a/packages/server/src/splitter/markdown-splitter.ts
+++ b/packages/server/src/splitter/markdown-splitter.ts
@@ -35,6 +35,9 @@ export class MarkdownSplitter {
     documentPath: string,
     documentHash: string
   ): Array<Omit<Section, 'vector'>> {
+    // 0. YAML frontmatter を除去
+    content = this.removeFrontmatter(content);
+
     // 1. Markdownをパース
     const tokens = marked.lexer(content);
 
@@ -45,6 +48,41 @@ export class MarkdownSplitter {
     const sections = this.buildSections(structure, documentPath, documentHash);
 
     return sections;
+  }
+
+  /**
+   * YAML frontmatter を除去
+   * frontmatter は以下の形式を想定:
+   * ---
+   * key: value
+   * ---
+   */
+  private removeFrontmatter(content: string): string {
+    // 先頭が "---" で始まるかチェック（前後の空白は許容）
+    const trimmed = content.trimStart();
+    if (!trimmed.startsWith('---')) {
+      return content;
+    }
+
+    // 最初の "---" の後に2つ目の "---" を探す
+    const lines = trimmed.split('\n');
+    let endIndex = -1;
+
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trim() === '---') {
+        endIndex = i;
+        break;
+      }
+    }
+
+    // 2つ目の "---" が見つからない場合は、frontmatter ではないとみなす
+    if (endIndex === -1) {
+      return content;
+    }
+
+    // frontmatter 以降の内容を返す
+    const remainingLines = lines.slice(endIndex + 1);
+    return remainingLines.join('\n');
   }
 
   /**


### PR DESCRIPTION
## 修正内容

### 1. get_outline APIの3つの問題を修正

#### 問題1: セクションの並び順が不正
- **原因**: `order`フィールドでソートしていたため、検索順で表示されていた
- **修正**: `section_number`配列の辞書順でソートするように変更
- **影響**: セクションが正しい階層順で表示されるようになった

#### 問題2: YAML frontmatterが見出しとして扱われる
- **原因**: markdown-splitterでYAML frontmatterを除去していなかった
- **修正**: `removeFrontmatter()`メソッドを追加し、`---`区切りのメタデータを除去
- **影響**: メタデータブロックが見出しとしてインデックスされなくなった

#### 問題3: document rootが常に先頭に表示される
- **原因**: depth=0（document root）が結果に含まれていた
- **修正**: `sections.filter(s => s.depth > 0)`で除外
- **影響**: 実際のセクション（1.1, 1.2...）のみが表示されるようになった

### 2. H4/H5/H6修正のchangeset追加

#### 問題
- PR #19（H4/H5/H6見出しスキップ修正）でchangesetが追加されていなかった
- そのため、v1.4.6リリース時にserver@1.2.8のバージョンが上がらなかった
- npmに公開されたserver@1.2.8には修正が含まれていない（Gitタグには含まれている）

#### 修正
- `fix-h4-h5-h6-headers.md` changesetを追加
- 次のリリースでserver@1.2.9として正しくnpmに公開される

## テスト

- ✅ markdown-splitter: 28 tests passed（YAML frontmatter除去含む）
- ✅ get-outline: 4 tests passed（ソート順、section_number辞書順含む）
- ✅ 実際の動作確認: /tmp/test-h4-debug で検証済み

## 関連Issue

- get_outline問題（ユーザー報告）
- #18 H4/H5/H6見出しスキップ問題（changesetの追加漏れ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)