### PR TITLE
docs: ローカル固有のパスをリポジトリ相対パスに変更

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ search-docs/
 ### コーディング方針
 
 参考レシピ:
-- **pnpmモノレポ**: `~/Develop/otolab/ai-agent-prompts/recipes/pnpm-workspaces-typescript/`
-- **ドキュメント・コード・テスト同期**: `~/Develop/otolab/ai-agent-prompts/recipes/document-code-test/`
-- **Serena統合**: `~/Develop/otolab/ai-agent-prompts/recipes/serena-integration/`
+- **pnpmモノレポ**: `ai-agent-prompts/recipes/pnpm-workspaces-typescript/`
+- **ドキュメント・コード・テスト同期**: `ai-agent-prompts/recipes/document-code-test/`
+- **Serena統合**: `ai-agent-prompts/recipes/serena-integration/`
 
 ### search-docs利用
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -10,5 +10,5 @@
 ## 参考
 
 プロジェクト全体の作業方針については、以下を参照してください：
-- 個人作業指針: `~/Develop/otolab/ai-agent-prompts/agent-prompts/prompts/root.md`
-- レシピ集: `~/Develop/otolab/ai-agent-prompts/recipes/`
+- 個人作業指針: `ai-agent-prompts/agent-prompts/prompts/root.md`
+- レシピ集: `ai-agent-prompts/recipes/`


### PR DESCRIPTION
## Summary
- `~/Develop/otolab/ai-agent-prompts/` を `ai-agent-prompts/` に置き換え
- ドキュメントを環境非依存にし、他の開発者も参照しやすくしました

## 修正箇所
- AGENTS.md: 参考レシピのパス（3箇所）
- prompts/README.md: 参考ドキュメントのパス（2箇所）

## Test plan
- [x] ドキュメントの記載が意図通り修正されていることを確認
- [x] 変更が最小限であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)