### PR TITLE
chore: 全依存パッケージのバージョンを固定

### DIFF
--- a/.changeset/pin-dependency-versions.md
+++ b/.changeset/pin-dependency-versions.md
@@ -1,0 +1,11 @@
+---
+"@search-docs/server": patch
+"@search-docs/cli": patch
+"@search-docs/client": patch
+"@search-docs/db-engine": patch
+"@search-docs/mcp-server": patch
+"@search-docs/storage": patch
+"@search-docs/types": patch
+---
+
+全依存パッケージのバージョンを固定（Node.js/Python）

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     "changeset:publish": "changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.29.7",
-    "@eslint/js": "^9.0.0",
-    "@types/node": "^22.0.0",
-    "eslint": "^9.0.0",
-    "typescript": "^5.7.0",
-    "typescript-eslint": "^8.0.0",
-    "vite": "^7.1.12",
-    "vitest": "^4.0.5"
+    "@changesets/cli": "2.29.7",
+    "@eslint/js": "9.38.0",
+    "@types/node": "22.18.12",
+    "eslint": "9.38.0",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.46.2",
+    "vite": "7.1.12",
+    "vitest": "4.0.5"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,10 +30,10 @@
     "@search-docs/client": "workspace:*",
     "@search-docs/server": "workspace:*",
     "@search-docs/types": "workspace:*",
-    "commander": "^12.0.0"
+    "commander": "12.1.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "22.18.12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
     "@search-docs/types": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "22.18.12"
   },
   "keywords": [
     "client",

--- a/packages/db-engine/package.json
+++ b/packages/db-engine/package.json
@@ -24,8 +24,8 @@
     "@search-docs/types": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "vitest": "^4.0.5"
+    "@types/node": "22.18.12",
+    "vitest": "4.0.5"
   },
   "keywords": [
     "vector-search",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,16 +25,16 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.0",
+    "@modelcontextprotocol/sdk": "1.20.2",
     "@search-docs/cli": "workspace:*",
     "@search-docs/client": "workspace:*",
     "@search-docs/types": "workspace:*",
-    "commander": "^12.0.0",
-    "zod": "^3.22.0"
+    "commander": "12.1.0",
+    "zod": "3.25.76"
   },
   "devDependencies": {
-    "@coeiro-operator/mcp-debug": "^1.0.0",
-    "@types/node": "^22.0.0"
+    "@coeiro-operator/mcp-debug": "1.1.0",
+    "@types/node": "22.18.12"
   },
   "keywords": [
     "mcp",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,24 +19,24 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@parcel/watcher": "^2.5.1",
+    "@parcel/watcher": "2.5.1",
     "@search-docs/db-engine": "workspace:*",
     "@search-docs/storage": "workspace:*",
     "@search-docs/types": "workspace:*",
-    "cors": "^2.8.5",
-    "express": "^5.1.0",
-    "fast-glob": "^3.3.2",
-    "gpt-tokenizer": "^2.6.1",
-    "ignore": "^6.0.2",
-    "marked": "^16.0.0",
-    "minimatch": "^10.0.3",
-    "nanoid": "^5.0.11"
+    "cors": "2.8.5",
+    "express": "5.1.0",
+    "fast-glob": "3.3.3",
+    "gpt-tokenizer": "2.9.0",
+    "ignore": "6.0.2",
+    "marked": "16.4.1",
+    "minimatch": "10.0.3",
+    "nanoid": "5.1.6"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.19",
-    "@types/express": "^5.0.4",
-    "@types/node": "^22.0.0",
-    "vitest": "^2.1.9"
+    "@types/cors": "2.8.19",
+    "@types/express": "5.0.4",
+    "@types/node": "22.18.12",
+    "vitest": "2.1.9"
   },
   "keywords": [
     "vector-search",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,7 +22,7 @@
     "@search-docs/types": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "22.18.12"
   },
   "keywords": [
     "storage",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,28 +9,28 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.29.7
+        specifier: 2.29.7
         version: 2.29.7(@types/node@22.18.12)
       '@eslint/js':
-        specifier: ^9.0.0
+        specifier: 9.38.0
         version: 9.38.0
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
       eslint:
-        specifier: ^9.0.0
+        specifier: 9.38.0
         version: 9.38.0
       typescript:
-        specifier: ^5.7.0
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.0.0
+        specifier: 8.46.2
         version: 8.46.2(eslint@9.38.0)(typescript@5.9.3)
       vite:
-        specifier: ^7.1.12
+        specifier: 7.1.12
         version: 7.1.12(@types/node@22.18.12)
       vitest:
-        specifier: ^4.0.5
+        specifier: 4.0.5
         version: 4.0.5(@types/node@22.18.12)
 
   packages/cli:
@@ -45,11 +45,11 @@ importers:
         specifier: workspace:*
         version: link:../types
       commander:
-        specifier: ^12.0.0
+        specifier: 12.1.0
         version: 12.1.0
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
 
   packages/client:
@@ -59,7 +59,7 @@ importers:
         version: link:../types
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
 
   packages/db-engine:
@@ -69,16 +69,16 @@ importers:
         version: link:../types
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
       vitest:
-        specifier: ^4.0.5
+        specifier: 4.0.5
         version: 4.0.5(@types/node@22.18.12)
 
   packages/mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.17.0
+        specifier: 1.20.2
         version: 1.20.2
       '@search-docs/cli':
         specifier: workspace:*
@@ -90,23 +90,23 @@ importers:
         specifier: workspace:*
         version: link:../types
       commander:
-        specifier: ^12.0.0
+        specifier: 12.1.0
         version: 12.1.0
       zod:
-        specifier: ^3.22.0
+        specifier: 3.25.76
         version: 3.25.76
     devDependencies:
       '@coeiro-operator/mcp-debug':
-        specifier: ^1.0.0
+        specifier: 1.1.0
         version: 1.1.0
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
 
   packages/server:
     dependencies:
       '@parcel/watcher':
-        specifier: ^2.5.1
+        specifier: 2.5.1
         version: 2.5.1
       '@search-docs/db-engine':
         specifier: workspace:*
@@ -118,41 +118,41 @@ importers:
         specifier: workspace:*
         version: link:../types
       cors:
-        specifier: ^2.8.5
+        specifier: 2.8.5
         version: 2.8.5
       express:
-        specifier: ^5.1.0
+        specifier: 5.1.0
         version: 5.1.0
       fast-glob:
-        specifier: ^3.3.2
+        specifier: 3.3.3
         version: 3.3.3
       gpt-tokenizer:
-        specifier: ^2.6.1
+        specifier: 2.9.0
         version: 2.9.0
       ignore:
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2
       marked:
-        specifier: ^16.0.0
+        specifier: 16.4.1
         version: 16.4.1
       minimatch:
-        specifier: ^10.0.3
+        specifier: 10.0.3
         version: 10.0.3
       nanoid:
-        specifier: ^5.0.11
+        specifier: 5.1.6
         version: 5.1.6
     devDependencies:
       '@types/cors':
-        specifier: ^2.8.19
+        specifier: 2.8.19
         version: 2.8.19
       '@types/express':
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
       vitest:
-        specifier: ^2.1.9
+        specifier: 2.1.9
         version: 2.1.9(@types/node@22.18.12)
 
   packages/storage:
@@ -162,7 +162,7 @@ importers:
         version: link:../types
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 22.18.12
         version: 22.18.12
 
   packages/types: {}
@@ -230,6 +230,7 @@ packages:
 
   '@coeiro-operator/mcp-debug@1.1.0':
     resolution: {integrity: sha512-foeP/Kl9Q0ByM004c+Zpxv3vXMmYk05S8hYAOTLPqL4EhkBkBV/21KWz8MvFAVgsNqEXpS7KcwN1jJdym+ADeQ==}
+    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 description = "🐕️ ローカル文書検索システム - Markdown文書に対するVector検索機能を提供"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "lancedb>=0.5.0",
-    "pyarrow>=14.0.0",
-    "pandas>=2.0.0",
-    "numpy>=1.24.0",
-    "sentence-transformers>=2.2.0",
-    "protobuf>=4.0.0",
-    "sentencepiece>=0.1.99",
-    "pytest>=7.0.0",
-    "psutil>=5.9.0",
-    "duckdb>=0.9.0",
+    "lancedb==0.25.3",
+    "pyarrow==22.0.0",
+    "pandas==2.3.3",
+    "numpy==2.3.5",
+    "sentence-transformers==5.1.2",
+    "protobuf==6.33.1",
+    "sentencepiece==0.2.1",
+    "pytest==9.0.1",
+    "psutil==7.1.3",
+    "duckdb==1.4.2",
 ]


### PR DESCRIPTION
## Summary
- Node.js（npm）の全32個の外部依存関係を、現在インストール済みバージョンに固定（`^` 除去）
- Python（uv）の全10個の依存関係を、現在インストール済みバージョンに固定（`>=` → `==`）
- lockfile更新済み

## 主な変更
| 範囲 | 対象パッケージ数 |
|------|---------------|
| root devDependencies | 8 |
| packages/cli | 2 |
| packages/client | 1 |
| packages/db-engine | 2 |
| packages/mcp-server | 5 |
| packages/server | 12 |
| packages/storage | 1 |
| pyproject.toml | 10 |

## Test plan
- [x] `pnpm install` 正常完了
- [x] `pnpm build` 正常完了
- [x] `uv lock` 正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)