### PR TITLE
docs: CLI embeddingコマンド・共有Embeddingサーバのドキュメント追加

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,6 +24,7 @@ npx @search-docs/cli <command>
 - [server コマンド](#server-コマンド)
 - [search コマンド](#search-コマンド)
 - [index コマンド](#index-コマンド)
+- [embedding コマンド](#embedding-コマンド)
 - [config コマンド](#config-コマンド)
 - [終了コード](#終了コード)
 
@@ -489,6 +490,162 @@ Worker:
 - Running: ワーカーが実行中か
 - Processing: 現在処理中のタスク数
 - Queue: キューに残っているタスク数
+
+## embedding コマンド
+
+Embeddingサーバの起動・停止・状態確認を行います。
+
+Embeddingサーバはプロジェクト横断で共有利用できるため、PIDとログは `~/.search-docs/` に配置されます（プロジェクトごとの `.search-docs/` ではありません）。ホスト側でGPU/CoreMLアクセラレーションを利用したい場合や、複数プロジェクトでEmbeddingモデルを共有したい場合に便利です。
+
+### embedding start
+
+Embeddingサーバをデーモン起動します。
+
+```bash
+search-docs embedding start [options]
+```
+
+#### オプション
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--port <port>` | ポート番号 | `24281` |
+| `-f, --foreground` | フォアグラウンドで起動（開発時） | `false` |
+| `--runtime <runtime>` | ランタイム（`onnx` または `torch`） | `onnx` |
+| `--dimension <dim>` | ベクトル次元数 | `256` |
+
+#### 使用例
+
+```bash
+# バックグラウンドで起動（デフォルト）
+search-docs embedding start
+
+# フォアグラウンドで起動（開発時）
+search-docs embedding start --foreground
+
+# カスタムポートで起動
+search-docs embedding start --port 24282
+
+# torchランタイムで起動
+search-docs embedding start --runtime torch
+```
+
+#### 動作
+
+1. 既存サーバがないことを確認
+2. ポートの空き状況を確認
+3. `uv --project <db-engine> run python embedding_server.py` で起動
+4. `/health` エンドポイントでReadiness待ち（初回はモデルダウンロードで時間がかかる場合があります）
+5. PIDファイル（`~/.search-docs/embedding.pid`）を保存
+
+#### アクセラレータ自動検出
+
+ONNX Runtimeのアクセラレータを自動検出します：
+
+- **Apple Silicon**: CoreMLExecutionProvider（445/724ノード対応）
+- **NVIDIA GPU**: CUDAExecutionProvider
+- **それ以外**: CPUExecutionProvider
+
+#### モデルパス自動解決
+
+以下の優先順で探します：
+
+1. Docker内蔵パス（`/app/.cache/models/ruri-v3-30m-onnx`）
+2. プロジェクトキャッシュ（`cwd/.cache/models/ruri-v3-30m-onnx`）
+3. HuggingFace Hubから自動ダウンロード（`sirasagi62/ruri-v3-30m-ONNX`）
+
+#### 注意事項
+
+- すでにサーバが起動している場合は何もしません
+- 初回起動時はモデルのダウンロードに時間がかかります
+- ログは `~/.search-docs/embedding.log` に出力されます
+
+### embedding stop
+
+Embeddingサーバを停止します。
+
+```bash
+search-docs embedding stop
+```
+
+#### オプション
+
+なし
+
+#### 使用例
+
+```bash
+# サーバを停止
+search-docs embedding stop
+```
+
+#### 動作
+
+1. PIDファイル（`~/.search-docs/embedding.pid`）からプロセスIDを取得
+2. プロセスにSIGTERMシグナルを送信
+3. プロセスの終了を待機
+4. PIDファイルを削除
+
+#### 注意事項
+
+- サーバが起動していない場合はエラーになります
+
+### embedding status
+
+Embeddingサーバの状態を確認します。
+
+```bash
+search-docs embedding status
+```
+
+#### オプション
+
+なし
+
+#### 使用例
+
+```bash
+# サーバの状態を確認
+search-docs embedding status
+```
+
+#### 出力例
+
+```
+Embedding Server Status
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Status:     Running
+PID:        45678
+Port:       24281
+Model:      cl-nagoya/ruri-v3-30m
+Dimension:  256
+Started:    2026-04-21T10:30:00.000Z
+Log:        /Users/username/.search-docs/embedding.log
+```
+
+#### 表示項目
+
+- **Status**: `Running` または `Not running`
+- **PID**: プロセスID
+- **Port**: 待ち受けポート番号
+- **Model**: モデル名
+- **Dimension**: ベクトル次元数
+- **Started**: 起動日時
+- **Log**: ログファイルのパス
+
+### Docker MCPサーバからの利用
+
+Docker内のMCPサーバは、`host.docker.internal:24281` 経由でホスト側のEmbeddingサーバを自動検出します。ホスト側でEmbeddingサーバを起動しておくだけで、Docker MCPサーバが自動的に接続します。
+
+```bash
+# ホスト側でEmbeddingサーバを起動
+search-docs embedding start
+
+# Docker MCPサーバを起動（自動的にホスト側のEmbeddingサーバを検出）
+docker mcp run search-docs
+```
+
+詳細は [Docker構成](./docker-deployment.md) を参照してください。
 
 ## config コマンド
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -32,6 +32,8 @@ docker mcp run search-docs
 
 ### 共有利用（ヘビーユーザー / 複数プロジェクト）
 
+#### オプション1: Docker Embeddingサーバ
+
 ```bash
 # 1回だけ: Embeddingサーバを起動
 docker run -d \
@@ -49,6 +51,29 @@ docker mcp run search-docs
 → Embeddingサーバ自動検出 → 軽量動作（メモリ節約）
 
 メモリ: 120MB x N → 120MB x 1（共有サーバ）+ 軽量MCP x N
+
+#### オプション2: ホスト側Embeddingサーバ（GPU/CoreML対応）
+
+ホスト側でEmbeddingサーバを直接起動すると、GPU/CoreMLアクセラレーションを利用できます。Docker MCPサーバは `host.docker.internal:24281` 経由で自動検出します。
+
+```bash
+# ホスト側でEmbeddingサーバを起動（CLIツールが必要）
+search-docs embedding start
+
+# 各プロジェクト: Docker MCPサーバ（自動的にホスト側のEmbeddingサーバを検出）
+docker mcp run search-docs
+```
+
+**メリット**:
+- **GPU/CoreMLアクセラレーション**: Apple Silicon（CoreML）やNVIDIA GPU（CUDA）を活用
+- **高速な推論**: CPU-onlyのDockerコンテナより高速
+- **複数プロジェクト共有**: 1つのサーバで複数のMCPサーバから利用可能
+
+**前提条件**:
+- `@search-docs/cli` パッケージがインストールされていること（`npm install -g @search-docs/cli`）
+- ホスト側に `uv` と Python 3.12+ がインストールされていること
+
+**詳細**: [CLI コマンドリファレンス - embedding コマンド](./cli-reference.md#embedding-コマンド)
 
 ### Watcher調停（複数インスタンス）
 
@@ -181,12 +206,36 @@ fetch('http://localhost:24280/health')  // → IPv4 (127.0.0.1) に接続
 - `SEARCH_DOCS_DOCKER_EMBEDDING_URL` 環境変数は廃止
 - Embedding管理の責務がTypeScript側に一元化
 
-## MLX / GPU の制約
+## GPU / CoreML アクセラレーション
 
-- **Docker内でMLXは不可**（LinuxKit VMの壁）
+### Docker内の制約
+
+- **Docker内でMLX/CoreMLは不可**（LinuxKit VMの壁）
 - Docker内は**CPU-only運用**。ruri-v3-30mは軽量なのでCPU実用的
-- MLXを使いたい場合: ホスト側でEmbeddingサーバを直接実行（Docker外）
-  - 自動検出の3番 `http://host.docker.internal:24281/health` で繋がる
+
+### ホスト側Embeddingサーバ（推奨）
+
+GPU/CoreMLアクセラレーションを利用したい場合は、ホスト側でEmbeddingサーバを起動してください：
+
+```bash
+# ホスト側でEmbeddingサーバを起動
+search-docs embedding start
+
+# Docker MCPサーバから自動接続
+docker mcp run search-docs
+```
+
+**アクセラレータ自動検出**（ONNX Runtime）:
+- **Apple Silicon**: CoreMLExecutionProvider（445/724ノード対応）
+- **NVIDIA GPU**: CUDAExecutionProvider
+- **それ以外**: CPUExecutionProvider
+
+**自動検出の仕組み**:
+- Docker MCPサーバ起動時に `http://host.docker.internal:24281/health` を確認
+- ホスト側のEmbeddingサーバが見つかれば自動接続
+- 見つからなければDockerコンテナ内でローカルspawn起動（CPU-only）
+
+**詳細**: [CLI コマンドリファレンス - embedding コマンド](./cli-reference.md#embedding-コマンド)
 
 ## リソース制限
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -481,6 +481,24 @@ search-docs search <query> [options]
 | `index rebuild [paths...]` | インデックスを再構築 |
 | `index status` | インデックスの状態を確認 |
 
+### embedding コマンド
+
+Embeddingサーバの起動・停止・状態確認を行います。プロジェクト横断で共有利用でき、GPU/CoreMLアクセラレーションに対応しています。
+
+| コマンド | 説明 |
+|---------|------|
+| `embedding start [options]` | Embeddingサーバを起動 |
+| `embedding stop` | Embeddingサーバを停止 |
+| `embedding status` | Embeddingサーバの状態を確認 |
+
+**主なオプション**:
+- `--port <port>`: ポート番号（デフォルト: 24281）
+- `-f, --foreground`: フォアグラウンドで起動
+- `--runtime <runtime>`: `onnx`（デフォルト、GPU/CoreML対応）または `torch`
+- `--dimension <dim>`: ベクトル次元数（デフォルト: 256）
+
+詳細は [CLIリファレンス - embedding コマンド](./cli-reference.md#embedding-コマンド) を参照してください。
+
 ### config コマンド
 
 | コマンド | 説明 |


### PR DESCRIPTION
## Summary
- CLIリファレンスにembeddingコマンドグループ（start/stop/status）の詳細ドキュメントを追加
- Docker構成ガイドにホスト側Embeddingサーバ（GPU/CoreML対応）オプションを追記
- ユーザーガイドにembeddingコマンドのサマリーを追加

## Test plan
- [ ] ドキュメントのリンク・参照が正しいことを確認
- [ ] CLI実機動作は PR #72 で検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)