### PR TITLE
feat: add_related_projectにURL接続オプションを追加

### DIFF
--- a/packages/mcp-server/src/server-manager.ts
+++ b/packages/mcp-server/src/server-manager.ts
@@ -286,6 +286,13 @@ export class ServerManager {
       throw new Error(`プロジェクト "${projectName}" のサーバは起動していません。`);
     }
 
+    // URL接続のサーバは外部管理なので停止処理をスキップ
+    if (serverInfo.projectRoot === '') {
+      console.error(`[mcp-server] Skipping stop for URL-connected project: ${projectName}`);
+      this.servers.delete(projectName);
+      return;
+    }
+
     // CLIのstopServer経由で停止
     const { stopServer } = await import('@search-docs/cli/commands/server/stop');
     const { configPath } = await ConfigLoader.resolve({
@@ -329,6 +336,42 @@ export class ServerManager {
       );
     }
 
+    // URL指定の場合は直接クライアント作成
+    if (relatedConfig.url) {
+      console.error(`[mcp-server] Connecting to URL for project: ${projectName} (${relatedConfig.url})`);
+      const client = new SearchDocsClient({ baseUrl: relatedConfig.url });
+
+      // 接続確認
+      try {
+        await client.healthCheck();
+        console.error(`[mcp-server] ✓ Connection established for project: ${projectName}`);
+      } catch (error) {
+        throw new Error(
+          `関連プロジェクト "${projectName}" のサーバ (URL: ${relatedConfig.url}) に接続できません。\n` +
+          `エラー: ${(error as Error).message}`
+        );
+      }
+
+      // キャッシュに保存（URL接続の場合はport不要、projectRootは空文字列）
+      const serverInfo: ServerInfo = {
+        client,
+        port: 0, // URL接続時はポート番号不要
+        projectRoot: '', // URL接続時はプロジェクトルート不要
+        projectName,
+      };
+      this.servers.set(projectName, serverInfo);
+      console.error(`[mcp-server] URL client cached for project: ${projectName}`);
+
+      return client;
+    }
+
+    // dir指定の場合は既存の起動処理
+    if (!relatedConfig.dir) {
+      throw new Error(
+        `関連プロジェクト "${projectName}" の設定に "dir" または "url" が必要です。`
+      );
+    }
+
     // ConfigLoader で設定を解決
     const resolved = await ConfigLoader.resolve({
       cwd: relatedConfig.dir,
@@ -352,7 +395,7 @@ export class ServerManager {
 
   /**
    * 設定ファイルと一時追加分をマージした関連プロジェクト一覧を取得
-   * 返却値のdirは全て絶対パスに解決済み
+   * 返却値のdirは全て絶対パスに解決済み（urlの場合はdirなし）
    */
   getAllRelatedProjects(
     configRelated?: Record<string, RelatedProjectConfig>,
@@ -364,10 +407,15 @@ export class ServerManager {
     if (configRelated && configPath) {
       const baseDir = path.dirname(configPath);
       for (const [name, config] of Object.entries(configRelated)) {
-        merged[name] = {
-          ...config,
-          dir: path.resolve(baseDir, config.dir),
-        };
+        // URL指定の場合はdirの解決不要
+        if (config.url) {
+          merged[name] = { ...config };
+        } else if (config.dir) {
+          merged[name] = {
+            ...config,
+            dir: path.resolve(baseDir, config.dir),
+          };
+        }
       }
     }
 

--- a/packages/mcp-server/src/server-manager.ts
+++ b/packages/mcp-server/src/server-manager.ts
@@ -338,8 +338,9 @@ export class ServerManager {
 
     // URL指定の場合は直接クライアント作成
     if (relatedConfig.url) {
-      console.error(`[mcp-server] Connecting to URL for project: ${projectName} (${relatedConfig.url})`);
-      const client = new SearchDocsClient({ baseUrl: relatedConfig.url });
+      const baseUrl = ServerManager.resolveDockerUrl(relatedConfig.url);
+      console.error(`[mcp-server] Connecting to URL for project: ${projectName} (${baseUrl})`);
+      const client = new SearchDocsClient({ baseUrl });
 
       // 接続確認
       try {
@@ -425,5 +426,13 @@ export class ServerManager {
     }
 
     return merged;
+  }
+
+  /**
+   * Docker環境ではlocalhost/127.0.0.1をhost.docker.internalに置換
+   */
+  static resolveDockerUrl(url: string): string {
+    if (process.env.IS_DOCKER !== 'true') return url;
+    return url.replace(/\/\/(localhost|127\.0\.0\.1)([:\/]|$)/, '//host.docker.internal$2');
   }
 }

--- a/packages/mcp-server/src/tools/add-related-project.ts
+++ b/packages/mcp-server/src/tools/add-related-project.ts
@@ -6,6 +6,7 @@
 import * as path from 'path';
 import { z } from 'zod';
 import { ConfigLoader } from '@search-docs/types';
+import { SearchDocsClient } from '@search-docs/client';
 import type { ToolRegistrationContext, RegisteredTool } from './types.js';
 
 /**
@@ -18,15 +19,27 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
     'add_related_project',
     {
       description:
-        '関連プロジェクトを一時的に追加します。追加されたプロジェクトはセッション中のみ有効で、設定ファイルには保存されません。指定ディレクトリに .search-docs.json が存在する必要があります。\n（.search-docs/config.json も自動検出されます）',
+        '関連プロジェクトを一時的に追加します。追加されたプロジェクトはセッション中のみ有効で、設定ファイルには保存されません。\n' +
+        'dirまたはurlのいずれか一方を指定します。\n' +
+        '- dir: 指定ディレクトリに .search-docs.json が存在する必要があります（.search-docs/config.json も自動検出）\n' +
+        '- url: 起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください。Docker環境からはhttp://host.docker.internal:<port>、ローカルではhttp://localhost:<port>を使用します',
       inputSchema: {
         name: z.string().describe('プロジェクト名（一意の識別子）'),
-        dir: z.string().describe('プロジェクトディレクトリ（相対パスまたは絶対パス）'),
+        dir: z.string().optional().describe('プロジェクトディレクトリ（相対パスまたは絶対パス）'),
+        url: z.string().optional().describe('起動済みサーバのURL。Docker内: http://host.docker.internal:<port>、ローカル: http://localhost:<port>'),
         description: z.string().optional().describe('プロジェクトの説明'),
       },
     },
-    async (args: { name: string; dir: string; description?: string }) => {
-      const { name, dir, description } = args;
+    async (args: { name: string; dir?: string; url?: string; description?: string }) => {
+      const { name, dir, url, description } = args;
+
+      // dir と url の排他チェック
+      if (!dir && !url) {
+        throw new Error('dir または url のいずれか一方を指定してください。');
+      }
+      if (dir && url) {
+        throw new Error('dir と url は同時に指定できません。どちらか一方のみを指定してください。');
+      }
 
       // 名前の重複チェック（設定ファイル + 一時追加分）
       const allRelated = serverManager.getAllRelatedProjects(
@@ -37,6 +50,50 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
         throw new Error(
           `関連プロジェクト "${name}" は既に登録されています。`
         );
+      }
+
+      // URL 指定時の処理
+      if (url) {
+        // ヘルスチェックで接続確認
+        const client = new SearchDocsClient({ baseUrl: url });
+        try {
+          await client.healthCheck();
+        } catch (error) {
+          throw new Error(
+            `指定されたURLのサーバに接続できません: ${url}\n\n` +
+            `エラー: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+
+        // 一時追加（URL形式）
+        serverManager.addTemporaryRelatedProject(name, {
+          url,
+          description,
+        });
+
+        let resultText = `✅ 関連プロジェクト "${name}" を一時的に追加しました。\n\n`;
+        resultText += `  URL: ${url}\n`;
+        if (description) {
+          resultText += `  説明: ${description}\n`;
+        }
+        resultText += `\n⚠️  この追加はセッション中のみ有効です。永続化するには設定ファイルを編集してください。\n\n`;
+        resultText += '次のステップ:\n';
+        resultText += `  - 検索を実行: search(query: "...", project: "${name}")\n`;
+        resultText += `  - 一覧を確認: list_related_projects\n`;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: resultText,
+            },
+          ],
+        };
+      }
+
+      // dir 指定時の処理（既存のまま）
+      if (!dir) {
+        throw new Error('dir が指定されていません。');
       }
 
       // ディレクトリを解決（プロジェクトルートからの相対パス）

--- a/packages/mcp-server/src/tools/add-related-project.ts
+++ b/packages/mcp-server/src/tools/add-related-project.ts
@@ -22,11 +22,11 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
         '関連プロジェクトを一時的に追加します。追加されたプロジェクトはセッション中のみ有効で、設定ファイルには保存されません。\n' +
         'dirまたはurlのいずれか一方を指定します。\n' +
         '- dir: 指定ディレクトリに .search-docs.json が存在する必要があります（.search-docs/config.json も自動検出）\n' +
-        '- url: 起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください。Docker環境からはhttp://host.docker.internal:<port>、ローカルではhttp://localhost:<port>を使用します',
+        '- url: 起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください（Docker環境ではlocalhostを自動でhost.docker.internalに補正します）',
       inputSchema: {
         name: z.string().describe('プロジェクト名（一意の識別子）'),
         dir: z.string().optional().describe('プロジェクトディレクトリ（相対パスまたは絶対パス）'),
-        url: z.string().optional().describe('起動済みサーバのURL。Docker内: http://host.docker.internal:<port>、ローカル: http://localhost:<port>'),
+        url: z.string().optional().describe('起動済みサーバのURL（例: http://localhost:<port>）'),
         description: z.string().optional().describe('プロジェクトの説明'),
       },
     },
@@ -54,8 +54,9 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
 
       // URL 指定時の処理
       if (url) {
-        // ヘルスチェックで接続確認
-        const client = new SearchDocsClient({ baseUrl: url });
+        const { ServerManager } = await import('../server-manager.js');
+        const resolvedUrl = ServerManager.resolveDockerUrl(url);
+        const client = new SearchDocsClient({ baseUrl: resolvedUrl });
         try {
           await client.healthCheck();
         } catch (error) {

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -27,7 +27,7 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
           statusText += 'search-docsがまだセットアップされていません。\n\n';
           statusText += 'セットアップ方法:\n';
           statusText += '  - 設定ファイルを作成: init\n';
-          statusText += '  - 関連プロジェクトを追加: add_related_project\n';
+          statusText += '  - 関連プロジェクトを追加: add_related_project（dirでローカル追加、urlで起動済みサーバに接続）\n';
 
           // 一時追加の関連プロジェクトがあれば表示
           const notConfiguredRelated = context.serverManager.getAllRelatedProjects();
@@ -43,7 +43,11 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
                 statusText += ` - ${projectConfig.description}`;
               }
               statusText += '\n';
-              statusText += `    ディレクトリ: ${projectConfig.dir}\n`;
+              if (projectConfig.url) {
+                statusText += `    URL: ${projectConfig.url}\n`;
+              } else {
+                statusText += `    ディレクトリ: ${projectConfig.dir}\n`;
+              }
               if (serverInfo) {
                 try {
                   await serverInfo.client.healthCheck();
@@ -133,9 +137,14 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
                     statusText += ' (停止中)';
                   }
                 }
+                if (projectConfig.url) {
+                  statusText += ` [URL: ${projectConfig.url}]`;
+                }
                 statusText += '\n';
               }
             }
+
+            statusText += '\n他のプロジェクトの文書を検索するには: add_related_project\n';
           }
 
           break;

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -3,8 +3,10 @@
  */
 
 export interface RelatedProjectConfig {
-  /** プロジェクトディレクトリ（相対パスまたは絶対パス） */
-  dir: string;
+  /** プロジェクトディレクトリ（相対パスまたは絶対パス）。url と排他 */
+  dir?: string;
+  /** リモートサーバURL（例: http://localhost:24280）。dir と排他 */
+  url?: string;
   /** プロジェクトの説明（オプション） */
   description?: string;
 }

--- a/packages/types/src/config/loader.ts
+++ b/packages/types/src/config/loader.ts
@@ -259,7 +259,7 @@ export class ConfigLoader {
     projectRoot: string;
   } | null> {
     const relatedProject = relatedProjects[projectName];
-    if (!relatedProject) {
+    if (!relatedProject || !relatedProject.dir) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

- `add_related_project` に `url` パラメータを追加。起動済みのsearch-docsサーバにURL指定で接続可能に
- Docker MCP環境では `IS_DOCKER=true` 時に localhost → host.docker.internal を自動補正
- `system_status` に `add_related_project` への誘導を追加

## 背景

Docker MCPコンテナからホスト側の別プロジェクトのsearch-docsサーバに接続したいが、コンテナ内からはホストのディレクトリにアクセスできない。CLIでサーバを起動し、URLで接続する方式で解決。

## 変更ファイル

- `packages/types/src/config.ts` — `RelatedProjectConfig` に `url` フィールド追加
- `packages/types/src/config/loader.ts` — `dir` optional 対応
- `packages/mcp-server/src/tools/add-related-project.ts` — `url` パラメータ追加、排他バリデーション
- `packages/mcp-server/src/server-manager.ts` — URL接続パス追加、Docker URL自動補正
- `packages/mcp-server/src/tools/system-status.ts` — URL接続の表示対応、誘導追加

## Test plan

- [ ] `pnpm build` 通過確認
- [ ] dir指定での既存動作が壊れていないこと
- [ ] url指定で起動済みサーバに接続できること
- [ ] Docker環境でlocalhost → host.docker.internal 補正が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)