### PR TITLE
fix: デフォルトhostをlocalhostから127.0.0.1に変更(IPv6リッスン問題)

### DIFF
--- a/packages/cli/src/commands/config/__tests__/init.test.ts
+++ b/packages/cli/src/commands/config/__tests__/init.test.ts
@@ -36,7 +36,7 @@ describe('config init', () => {
 
     expect(config.version).toBe('1.0');
     expect(config.project.name).toMatch(/\.test-config-init-/);
-    expect(config.server.host).toBe('localhost');
+    expect(config.server.host).toBe('127.0.0.1');
     expect(config.server.port).toBeGreaterThanOrEqual(49152);
     expect(config.server.port).toBeLessThanOrEqual(65535);
   });

--- a/packages/cli/src/commands/config/init.ts
+++ b/packages/cli/src/commands/config/init.ts
@@ -68,7 +68,7 @@ function createDefaultConfig(options: {
       includeCleanOnly: false,
     },
     server: {
-      host: 'localhost',
+      host: '127.0.0.1',
       port: options.port,
       protocol: 'json-rpc',
     },

--- a/packages/cli/src/commands/embedding/start.ts
+++ b/packages/cli/src/commands/embedding/start.ts
@@ -31,7 +31,7 @@ async function startEmbeddingServer(options: EmbeddingStartOptions): Promise<voi
   const dimension = options.dimension ? parseInt(options.dimension, 10) : 256;
 
   // 既存サーバチェック
-  const existing = await checkEmbeddingHealth('localhost', port);
+  const existing = await checkEmbeddingHealth('127.0.0.1', port);
   if (existing) {
     console.log(`Embedding server is already running on port ${port}`);
     console.log(`  Model: ${existing.model}`);
@@ -92,7 +92,7 @@ async function startEmbeddingServer(options: EmbeddingStartOptions): Promise<voi
 
   // readiness 待ち（初回はモデルダウンロードで時間がかかる）
   console.log('Waiting for embedding server to start (initial download may take a few minutes)...');
-  const ready = await waitForEmbeddingReady('localhost', port, 120000);
+  const ready = await waitForEmbeddingReady('127.0.0.1', port, 120000);
 
   if (!ready) {
     try { process.kill(proc.pid, 'SIGTERM'); } catch { /* ignore */ }
@@ -100,7 +100,7 @@ async function startEmbeddingServer(options: EmbeddingStartOptions): Promise<voi
   }
 
   // PIDファイル保存
-  const health = await checkEmbeddingHealth('localhost', port);
+  const health = await checkEmbeddingHealth('127.0.0.1', port);
   const pidFile = {
     pid: proc.pid,
     port,

--- a/packages/cli/src/commands/embedding/status.ts
+++ b/packages/cli/src/commands/embedding/status.ts
@@ -32,7 +32,7 @@ async function showEmbeddingStatus(options: EmbeddingStatusOptions): Promise<voi
   } catch { /* no pid file */ }
 
   // ヘルスチェック
-  const health = await checkEmbeddingHealth('localhost', port);
+  const health = await checkEmbeddingHealth('127.0.0.1', port);
 
   if (!health) {
     if (pidFile && !isProcessAlive(pidFile.pid)) {
@@ -47,7 +47,7 @@ async function showEmbeddingStatus(options: EmbeddingStatusOptions): Promise<voi
   console.log('Embedding server: Running');
   console.log(`  Model: ${health.model}`);
   console.log(`  Dimension: ${health.vectorDimension}`);
-  console.log(`  URL: http://localhost:${port}`);
+  console.log(`  URL: http://127.0.0.1:${port}`);
 
   if (pidFile && isProcessAlive(pidFile.pid)) {
     console.log(`  PID: ${pidFile.pid}`);

--- a/packages/cli/src/utils/server-url.ts
+++ b/packages/cli/src/utils/server-url.ts
@@ -36,7 +36,7 @@ export async function resolveServerUrl(
   });
 
   // server設定からURLを構築
-  const host = config.server.host || 'localhost';
+  const host = config.server.host || '127.0.0.1';
   const port = config.server.port || 24280;
   return `http://${host}:${port}`;
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -23,7 +23,7 @@ import type {
  * クライアント設定
  */
 export interface SearchDocsClientConfig {
-  /** サーバURL（デフォルト: http://localhost:24280） */
+  /** サーバURL（デフォルト: http://127.0.0.1:24280） */
   baseUrl?: string;
   /** リクエストタイムアウト（ミリ秒、デフォルト: 30000） */
   timeout?: number;
@@ -54,7 +54,7 @@ export class SearchDocsClient {
   private requestId = 0;
 
   constructor(config: SearchDocsClientConfig = {}) {
-    this.baseUrl = config.baseUrl || 'http://localhost:24280';
+    this.baseUrl = config.baseUrl || 'http://127.0.0.1:24280';
     this.timeout = config.timeout || 30000;
   }
 

--- a/packages/mcp-server/src/server-manager.ts
+++ b/packages/mcp-server/src/server-manager.ts
@@ -138,7 +138,7 @@ export class ServerManager {
       console.error('[mcp-server] Waiting for server to start...');
 
       // サーバのヘルスチェックを行う（最大30秒待機）
-      const serverUrl = `http://localhost:${port}`;
+      const serverUrl = `http://127.0.0.1:${port}`;
       const client = new SearchDocsClient({ baseUrl: serverUrl });
       const maxWaitTime = 30000; // 30秒
       const checkInterval = 1000; // 1秒
@@ -239,7 +239,7 @@ export class ServerManager {
     await this.startServer(projectRoot, port, configPath);
 
     // クライアントを作成してキャッシュ
-    const serverUrl = `http://localhost:${port}`;
+    const serverUrl = `http://127.0.0.1:${port}`;
     const client = new SearchDocsClient({ baseUrl: serverUrl });
 
     const serverInfo: ServerInfo = {

--- a/packages/server/src/bin/server.ts
+++ b/packages/server/src/bin/server.ts
@@ -133,7 +133,7 @@ async function main() {
     // SearchDocsサーバ初期化
     const searchDocsServer = new SearchDocsServer(config, storage, dbEngine, packageJson.version);
 
-    // Docker環境ではIPv4/IPv6両方でリッスン（localhostだとIPv6のみになる場合がある）
+    // Docker環境では全インターフェースでリッスン（コンテナ外からアクセス可能にする）
     const serverHost = process.env.IS_DOCKER === 'true' ? '0.0.0.0' : config.server.host;
 
     // JSON-RPCサーバ初期化

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -53,7 +53,7 @@ export interface IndexingConfig {
   vectorDimension: number;
   /** 埋め込みモデル（情報表示用、実際のモデルはembedding serverが管理） */
   embeddingModel: string;
-  /** Embedding ServerのURL（デフォルト: http://localhost:24281） */
+  /** Embedding ServerのURL（デフォルト: http://127.0.0.1:24281） */
   embeddingUrl?: string;
 }
 
@@ -131,7 +131,7 @@ export const DEFAULT_CONFIG: SearchDocsConfig = {
     maxDepth: 3,
     vectorDimension: 256,
     embeddingModel: 'ruri-v3-30m-onnx',
-    embeddingUrl: 'http://localhost:24281',
+    embeddingUrl: 'http://127.0.0.1:24281',
   },
   search: {
     defaultLimit: 10,
@@ -139,7 +139,7 @@ export const DEFAULT_CONFIG: SearchDocsConfig = {
     includeCleanOnly: false,
   },
   server: {
-    host: 'localhost',
+    host: '127.0.0.1',
     port: 24280,
     protocol: 'json-rpc',
   },


### PR DESCRIPTION
## Summary

- デフォルトの `host` 設定を `localhost` から `127.0.0.1` に変更
- Node.js `server.listen('localhost')` がmacOSでIPv6(`::1`)のみにバインドされ、undici/fetchのIPv4優先により接続が失敗する問題を解消
- サーバ側デフォルト値、クライアントライブラリ、CLI、MCP Serverの全接続箇所を統一的に修正

## 変更箇所（8ファイル）

| パッケージ | ファイル | 内容 |
|-----------|---------|------|
| types | `config.ts` | デフォルト `host` と `embeddingUrl` |
| client | `client.ts` | デフォルト `baseUrl` |
| cli | `server-url.ts` | URL構築のフォールバック |
| cli | `init.ts` | 設定初期化のデフォルト |
| cli | `embedding/start.ts` | Embeddingサーバ接続 |
| cli | `embedding/status.ts` | Embeddingステータス確認 |
| mcp-server | `server-manager.ts` | サーバ起動・接続URL |
| server | `server.ts` | Docker分岐コメント更新 |

## 設計判断

- `0.0.0.0` ではなく `127.0.0.1` を選択：ローカル専用ツールのためループバック外への露出を避ける
- Docker環境は既存の `IS_DOCKER` 分岐で `0.0.0.0` を使用済みのため変更不要
- `server-manager.ts` のDocker URL置換ロジック（`localhost/127.0.0.1` → `host.docker.internal`）は既に両方を処理するため影響なし

## Test plan

- [x] TypeScriptビルド通過
- [x] Serverパッケージテスト全パス（9ファイル, 85テスト）
- [ ] macOS環境でのサーバ起動・接続の実機確認

refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)