### PR TITLE
refactor: MCPサービスin-process化 & 関連プロジェクトURL限定化

### DIFF
--- a/.changeset/mcp-in-process.md
+++ b/.changeset/mcp-in-process.md
@@ -1,0 +1,14 @@
+---
+"@search-docs/types": minor
+"@search-docs/server": patch
+"@search-docs/client": patch
+"@search-docs/mcp-server": minor
+"@search-docs/db-engine": patch
+---
+
+MCPサービスをin-process化し、関連プロジェクトをURL接続に限定
+
+- SearchDocsServiceインターフェイスを追加し、in-processとHTTPアクセスを透過的に扱えるように
+- MCPサーバがSearchDocsServerインスタンスを直接保持する構成に変更（HTTPデーモンspawn廃止）
+- RelatedProjectConfigからdir指定を削除し、url必須に変更
+- db-engineのget_statsで内部API(_dataset)を公開API(to_lance())に修正

--- a/.changeset/mcp-in-process.md
+++ b/.changeset/mcp-in-process.md
@@ -1,8 +1,8 @@
 ---
-"@search-docs/types": minor
+"@search-docs/types": patch
 "@search-docs/server": patch
 "@search-docs/client": patch
-"@search-docs/mcp-server": minor
+"@search-docs/mcp-server": patch
 "@search-docs/db-engine": patch
 ---
 

--- a/.changeset/mcp-in-process.md
+++ b/.changeset/mcp-in-process.md
@@ -12,3 +12,6 @@ MCPサービスをin-process化し、関連プロジェクトをURL接続に限�
 - MCPサーバがSearchDocsServerインスタンスを直接保持する構成に変更（HTTPデーモンspawn廃止）
 - RelatedProjectConfigからdir指定を削除し、url必須に変更
 - db-engineのget_statsで内部API(_dataset)を公開API(to_lance())に修正
+- lancedb 0.25.3 → 0.30.2へアップデート（Lance v3.0対応）
+- Python依存を全てバージョン固定（サプライチェーン対策）
+- torch/sentence-transformers依存を削除（ONNX移行済み）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,34 +6,34 @@
 
 ## アーキテクチャ
 
-### クライアント・サーバ構成
+### プロセス構成
 
 ```
-MCP Server
-    ↓ JSON-RPC
-JSON-RPC Server (WatcherProcess内蔵)
-    ↓
-┌───────────────────┬────────────────────┐
-│                   │                    │
-WatcherProcess   DBEngine           Embedding Server
-(heartbeat調停)  (read/write)        (stateless)
-│                   │                    │
-└───────────────────┴────────────────────┘
-        LanceDB (共有ストレージ)
+MCP Server (stdio)
+  ├─ in-process: SearchDocsServer (read-only)
+  ├─ in-process: WatcherProcess (write, heartbeat調停)
+  ├─ in-process: DBEngine
+  └─ subprocess: Embedding Server (stateless, 共有可能)
+           │
+           ▼
+       LanceDB (共有ストレージ)
 ```
 
 **詳細**: docs/client-server-architecture.md
 
-### プロセス構成
+### アーキテクチャ構成
 
-search-docsは以下の3つのプロセス役割で構成されます：
+search-docsは以下の構成で動作します：
 
 1. **MCP Server** (`packages/mcp-server/`)
    - Claude Code統合、stdio通信
+   - **SearchDocsServerをin-processで直接保持**（HTTPデーモン不要）
+   - SearchDocsServiceインターフェイス経由でサーバ機能を利用
 
 2. **JSON-RPC Server** (`packages/server/src/bin/server.ts`)
-   - HTTP JSON-RPCサーバ、WatcherProcess内蔵
-   - Heartbeat調停で複数インスタンス間を自動協調
+   - `search-docs server start` コマンドでHTTPサーバとしてexposeする用途
+   - WatcherProcess内蔵、Heartbeat調停で複数インスタンス間を自動協調
+   - MCPサーバからは使用されない（外部クライアント向け）
 
 3. **Embedding Server** (`packages/db-engine/src/python/embedding_server.py`)
    - Ollama API互換のHTTP埋め込みサーバ

--- a/README.md
+++ b/README.md
@@ -142,21 +142,27 @@ const results = await client.search('検索クエリ');
 
 ## アーキテクチャ概要
 
-search-docsは**クライアント・サーバ構成**です：
+search-docsは**in-process構成（MCPサーバ）** と **クライアント・サーバ構成（HTTPサーバ）** の2つのモードで動作します：
 
-### Server側
-- **Server** (`@search-docs/server`): プロジェクトごとに起動
-  - DocumentStorage: ファイルの変更検知
-  - SearchIndex: LanceDBによるVector検索
-  - IndexWorker: バックグラウンドでの自動更新
+### MCPサーバモード（Claude Code統合）
+- **MCP Server** (`@search-docs/mcp-server`): SearchDocsServerをin-processで直接保持
+  - HTTPデーモン不要、高速起動
+  - SearchDocsServer（read-only）
+  - WatcherProcess（write、heartbeat調停）
+  - DBEngine（Python/LanceDB/Ruri）
+  - EmbeddingServerProcess（自動検出・起動）
 
-### Client側
-- **MCP Server** (`@search-docs/mcp-server`): Claude Code統合
+### HTTPサーバモード（外部クライアント向け）
+- **Server** (`@search-docs/server`): `server start` コマンドで起動
+  - JSON-RPC API提供
+  - CLI Tool、Client Libraryから利用
 - **CLI Tool** (`@search-docs/cli`): コマンドライン
 - **Client Library** (`@search-docs/client`): プログラマティックな利用
 
-### DB Engine
-- **DB Engine** (`@search-docs/db-engine`): Python/LanceDB/Ruri
+### 共通インターフェイス
+- **SearchDocsService**: MCPサーバとHTTPクライアントの共通インターフェイス
+  - SearchDocsServer（in-process実装）
+  - SearchDocsClient（HTTP実装）
 
 詳細: [システムアーキテクチャ](docs/architecture.md) | [データモデル](docs/data-model.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,18 +24,27 @@ search-docsは、ローカル文書のVector検索を実現するための多層
 
 ## プロセス構成
 
-search-docsは以下の3つのプロセス役割で構成されます。
+search-docsは以下の構成で動作します。
 
 ### 1. MCP Server (`packages/mcp-server/`)
 
 - **役割**: Claude Code統合、stdio通信
-- **通信**: クライアント → JSON-RPC Server
+- **実装**: SearchDocsServerをin-processで直接保持
+- **インターフェイス**: SearchDocsServiceインターフェイス経由でサーバ機能を利用
+- **機能**: search, getDocument, getOutline, getStatus
+- **内蔵コンポーネント**:
+  - SearchDocsServer（read-only）
+  - WatcherProcess（write、heartbeat調停）
+  - DBEngine
+  - EmbeddingServerProcess（自動検出・起動管理）
 
 ### 2. JSON-RPC Server (`packages/server/src/bin/server.ts`)
 
-- **役割**: HTTP JSON-RPCサーバ、検索APIの提供、WatcherProcess内蔵
+- **役割**: HTTPサーバとしてSearchDocsServerをexposeする
+- **用途**: `search-docs server start` コマンドで起動、外部クライアント向け
 - **機能**: search, getDocument, getOutline, getStatus
 - **WatcherProcess**: FileWatcher, IndexWorker, StartupSyncWorker（heartbeat調停で複数インスタンス間を自動協調）
+- **注**: MCPサーバからは使用されない（MCPはin-processで動作）
 
 ### 3. Embedding Server (`packages/db-engine/src/python/embedding_server.py`)
 
@@ -51,18 +60,38 @@ search-docsは以下の3つのプロセス役割で構成されます。
 ### プロセス間の関係
 
 ```
-MCP Server
-    ↓ JSON-RPC
-JSON-RPC Server (WatcherProcess内蔵)
-    ↓
-┌───────────────────┬────────────────────┐
-│                   │                    │
-WatcherProcess   DBEngine           Embedding Server
-(heartbeat調停)  (read/write)        (stateless)
-│                   │                    │
-└───────────────────┴────────────────────┘
-              LanceDB
+MCP Server (stdio)
+  ├─ in-process: SearchDocsServer (read-only)
+  ├─ in-process: WatcherProcess (write, heartbeat調停)
+  │   ├─ FileWatcher (master時のみ起動)
+  │   ├─ IndexWorker (master時のみ起動)
+  │   └─ StartupSyncWorker (master時のみ起動)
+  ├─ in-process: DBEngine
+  └─ subprocess: Embedding Server (stateless)
+           │
+           ▼
+       LanceDB (共有ストレージ)
+
+─────────────────────────────────────────
+
+JSON-RPC Server (HTTP) ← `server start` コマンドで起動
+  ├─ in-process: SearchDocsServer (read-only)
+  ├─ in-process: WatcherProcess (write, heartbeat調停)
+  ├─ in-process: DBEngine
+  └─ subprocess: Embedding Server (stateless)
+           │
+           ▼
+       LanceDB (共有ストレージ)
 ```
+
+**SearchDocsServiceインターフェイス**:
+
+MCPサーバとJSON-RPCクライアントは、共通のSearchDocsServiceインターフェイス（`packages/types/src/service.ts`）を実装することで、透過的にサーバ機能を利用できます：
+
+- **SearchDocsServer**: in-processで直接実装
+- **SearchDocsClient**: HTTP JSON-RPC経由で実装
+
+これにより、MCPツールはサーバがin-processかHTTP経由かを意識せずに利用できます。
 
 ## コアコンポーネント
 

--- a/docs/client-server-architecture.md
+++ b/docs/client-server-architecture.md
@@ -6,56 +6,88 @@ search-docsは、プロジェクト毎に起動される単一の文書管理・
 
 ## アーキテクチャ図
 
+### MCPサーバモード（in-process構成）
+
+```
+┌─────────────────────────────────────────┐
+│       MCP Server (Claude Code)          │
+│         (stdio通信)                     │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │  SearchDocsServer (read-only)   │   │
+│  │  - search, getDocument          │   │
+│  │  - getOutline, getStatus        │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │  WatcherProcess (write)         │   │
+│  │  - Heartbeat調停                │   │
+│  │  - FileWatcher (master時)       │   │
+│  │  - IndexWorker (master時)       │   │
+│  │  - StartupSyncWorker            │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │  DBEngine                       │   │
+│  │  - LanceDB操作                  │   │
+│  │  - Vector検索                   │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  ┌─────────────────────────────────┐   │
+│  │  EmbeddingServerProcess         │   │
+│  │  - 自動検出・起動管理           │   │
+│  └─────────────────────────────────┘   │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│              LanceDB                    │
+│  - documents                            │
+│  - sections                             │
+│  - writer_heartbeat (調停用)            │
+└─────────────────────────────────────────┘
+```
+
+### HTTPサーバモード（`server start` コマンド）
+
 ```
 ┌─────────────────────────────────────────┐
 │           Client Applications           │
 │  - CLI Tool                             │
-│  - MCP Server (Claude Code統合)        │
 │  - REST API Client                      │
 └──────────────┬──────────────────────────┘
                │ JSON-RPC / HTTP
                │
 ┌──────────────▼──────────────────────────┐
-│       SearchDocsServer (read-only)      │
-│  (プロジェクト毎に1インスタンス)        │
+│   JSON-RPC Server (HTTP)                │
 │                                         │
 │  ┌─────────────────────────────────┐   │
-│  │   Configuration Loader          │   │
-│  │   - ファイル検索ルール          │   │
-│  │   - インデックス設定            │   │
+│  │  SearchDocsServer (read-only)   │   │
+│  │  - search, getDocument          │   │
+│  │  - getOutline, getStatus        │   │
 │  └─────────────────────────────────┘   │
 │                                         │
 │  ┌─────────────────────────────────┐   │
-│  │   Search Engine                 │   │
-│  │   - SearchIndex (LanceDB)       │   │
-│  │   - Vector検索                  │   │
-│  └─────────────────────────────────┘   │
-└─────────────────────────────────────────┘
-
-┌─────────────────────────────────────────┐
-│      WatcherProcess (write)             │
-│  (独立プロセス、Heartbeat調停あり)      │
-│                                         │
-│  ┌─────────────────────────────────┐   │
-│  │   Heartbeat Coordinator         │   │
-│  │   - Master選出                  │   │
-│  │   - 状態マシン管理              │   │
+│  │  WatcherProcess (write)         │   │
+│  │  - Heartbeat調停                │   │
+│  │  - FileWatcher (master時)       │   │
+│  │  - IndexWorker (master時)       │   │
+│  │  - StartupSyncWorker            │   │
 │  └─────────────────────────────────┘   │
 │                                         │
 │  ┌─────────────────────────────────┐   │
-│  │   Document Manager              │   │
-│  │   - DocumentStorage             │   │
-│  │   - FileWatcher (master時)      │   │
+│  │  DBEngine                       │   │
+│  │  - LanceDB操作                  │   │
+│  │  - Vector検索                   │   │
 │  └─────────────────────────────────┘   │
 │                                         │
 │  ┌─────────────────────────────────┐   │
-│  │   Index Workers                 │   │
-│  │   - IndexWorker (master時)      │   │
-│  │   - StartupSyncWorker           │   │
+│  │  EmbeddingServerProcess         │   │
+│  │  - 自動検出・起動管理           │   │
 │  └─────────────────────────────────┘   │
-└─────────────────────────────────────────┘
-
-          ↓ 共有ストレージ（LanceDB）
+└──────────────┬──────────────────────────┘
+               │
+               ▼
 ┌─────────────────────────────────────────┐
 │              LanceDB                    │
 │  - documents                            │
@@ -71,9 +103,12 @@ search-docsは、プロジェクト毎に起動される単一の文書管理・
 #### 1. SearchDocsServer (Read-Only)
 
 **責務**:
-- プロジェクト毎に1インスタンスが起動
-- クライアントからの検索リクエストを処理
 - read-only操作のみ（search, getDocument, getOutline, getStatus）
+- クライアントからの検索リクエストを処理
+
+**実装形態**:
+- **MCPサーバ**: in-processで直接インスタンスを保持
+- **HTTPサーバ**: `server start` コマンドで起動、JSON-RPC経由でアクセス
 
 WatcherProcessを常に内蔵し、Heartbeat調停で複数インスタンス間を自動協調します。
 
@@ -84,7 +119,9 @@ WatcherProcessを常に内蔵し、Heartbeat調停で複数インスタンス間
 - Heartbeat調停による排他制御
 - 複数プロセス間で1つだけがmaster（watching状態）になる
 
-server.ts内で同一プロセスとして起動されます。
+**実装形態**:
+- MCPサーバ・HTTPサーバともに同一プロセス内で起動
+- SearchDocsServerと同じプロセスで動作
 
 **Heartbeat調停メカニズム**:
 
@@ -173,6 +210,12 @@ search-docs-server start --port 24280
     "name": "my-project",
     "root": "."
   },
+  "relatedProjects": {
+    "other-project": {
+      "url": "http://localhost:24281",
+      "description": "関連プロジェクトの説明（オプション）"
+    }
+  },
   "files": {
     "include": [
       "**/*.md",
@@ -218,6 +261,14 @@ search-docs-server start --port 24280
 }
 ```
 
+**関連プロジェクト設定（relatedProjects）**:
+
+- **目的**: 他のプロジェクトのsearch-docsサーバを検索対象に含める
+- **設定方法**: `relatedProjects` に名前とURL（必須）を指定
+- **接続方法**: MCPツールの `project` パラメータで関連プロジェクト名を指定
+- **サーバ起動**: 関連プロジェクトのサーバは**明示的に `search-docs server start` で起動**する必要があります
+- **変更点（v1.9.0以降）**: `dir` フィールドは削除され、`url` のみになりました（暗黙的なサーバ自動起動を廃止）
+
 **設定スキーマ（TypeScript）**:
 ```typescript
 interface SearchDocsConfig {
@@ -226,6 +277,7 @@ interface SearchDocsConfig {
     name: string;
     root: string;
   };
+  relatedProjects?: Record<string, RelatedProjectConfig>;
   files: {
     include: string[];      // globパターン
     exclude: string[];      // globパターン
@@ -260,6 +312,13 @@ interface SearchDocsConfig {
     pythonMaxMemoryMB?: number;        // Pythonワーカーの最大メモリ使用量（MB、デフォルト: 8192）
     memoryCheckIntervalMs?: number;    // メモリ監視の間隔（ms、デフォルト: 30000）
   };
+}
+
+interface RelatedProjectConfig {
+  /** リモートサーバURL（必須）例: http://localhost:24280 */
+  url: string;
+  /** プロジェクトの説明（オプション） */
+  description?: string;
 }
 ```
 
@@ -349,20 +408,47 @@ search-docs config init
 **実装**:
 ```typescript
 class SearchDocsMCPServer {
+  private service: SearchDocsService; // in-process SearchDocsServer
+
   async search(query: string, options?: SearchOptions) {
-    // クライアントを通じてサーバにリクエスト
-    return await this.client.search(query, options);
+    // in-processで直接実行（HTTPリクエスト不要）
+    return await this.service.search({ query, options });
   }
 
   async getDocument(path: string) {
-    return await this.client.getDocument(path);
+    return await this.service.getDocument({ path });
   }
 }
 ```
 
+**SearchDocsServiceインターフェイス**:
+
+MCPサーバとHTTPクライアントは、共通のSearchDocsServiceインターフェイス（`packages/types/src/service.ts`）を使用します：
+
+```typescript
+export interface SearchDocsService {
+  search(request: SearchRequest): Promise<SearchResponse>;
+  getDocument(request: GetDocumentRequest): Promise<GetDocumentResponse>;
+  getOutline(request: GetOutlineRequest): Promise<GetOutlineResponse>;
+  getStatus(): Promise<GetStatusResponse>;
+}
+```
+
+- **SearchDocsServer**: in-processで実装
+- **SearchDocsClient**: HTTP JSON-RPC経由で実装
+
+これにより、MCPツールはサーバがin-processかHTTP経由かを意識せずに利用できます。
+
 **Claude Code統合**:
 ```bash
-claude mcp add search-docs -- search-docs mcp-server --project $(pwd)
+# Docker版（推奨）
+docker run --rm -i \
+  -v .:/workspace:ro \
+  -v ./.search-docs:/workspace/.search-docs \
+  otolab/search-docs-mcp:latest
+
+# npx版
+claude mcp add npx -- -y @search-docs/mcp-server
 ```
 
 #### 3. Client Library

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -56,6 +56,7 @@ search-docsのMCP Serverは以下のツールを提供します。
 | `includeCleanOnly` | boolean | - | false | Clean（最新）なSectionのみ検索 |
 | `includePaths` | string[] | - | - | 含めるパス（前方一致）<br>例: `["docs/", "README.md"]` |
 | `excludePaths` | string[] | - | - | 除外するパス（前方一致）<br>例: `["docs/internal/"]` |
+| `project` | string | - | - | 関連プロジェクト名<br>指定時は関連プロジェクトを検索 |
 
 **使用例**:
 
@@ -100,6 +101,7 @@ Claude: [searchツールを使用]
 |-----------|-----|------|------|
 | `path` | string | - | 文書パス<br>例: `"docs/architecture.md"` |
 | `sectionId` | string | - | セクションID（検索結果から取得）|
+| `project` | string | - | 関連プロジェクト名<br>指定時は関連プロジェクトから取得 |
 
 **注意**: `path` と `sectionId` のどちらか一方は必須
 
@@ -149,6 +151,7 @@ LanceDBとRuri Embeddingを使用したVector検索エンジンです。
 |-----------|-----|------|------|
 | `path` | string | - | 文書パス |
 | `sectionId` | string | - | セクションID（そのセクション配下のアウトライン）|
+| `project` | string | - | 関連プロジェクト名<br>指定時は関連プロジェクトから取得 |
 
 **注意**: `path` と `sectionId` のどちらか一方は必須
 
@@ -255,6 +258,108 @@ Claude: [index_statusツールを使用]
 
 ---
 
+### 5. `system_status` - システム状態確認
+
+システム全体の状態を取得します。
+
+**パラメータ**: なし
+
+**使用例**:
+
+```
+ユーザー: システムの状態を確認して
+
+Claude: [system_statusツールを使用]
+```
+
+**レスポンス例**:
+
+```
+システム状態
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+状態: RUNNING
+プロジェクトルート: /path/to/project
+設定ファイル: .search-docs.json
+
+サーバ情報:
+  バージョン: 1.0.0
+  稼働時間: 2h 15m 30s
+
+データベース:
+  接続状態: ready
+  総文書数: 152
+  総セクション数: 1,018
+
+関連プロジェクト:
+  - other-project (http://localhost:24281)
+```
+
+---
+
+### 6. `add_related_project` - 関連プロジェクト追加
+
+他のプロジェクトのsearch-docsサーバを検索対象に追加します（一時的）。
+
+**パラメータ**:
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `name` | string | ✓ | プロジェクト名 |
+| `url` | string | ✓ | サーバURL（例: `http://localhost:24281`） |
+| `description` | string | - | 説明（オプション） |
+
+**使用例**:
+
+```
+ユーザー: ai-agent-promptsプロジェクトも検索対象に追加して
+
+Claude: [add_related_projectツールを使用]
+        name: "ai-agent-prompts"
+        url: "http://localhost:24281"
+        description: "エージェントプロンプト集"
+```
+
+**注意**:
+- 関連プロジェクトのサーバは**明示的に `search-docs server start` で起動**しておく必要があります
+- この追加は一時的なもので、設定ファイルには保存されません
+- 恒久的に追加したい場合は、設定ファイルの `relatedProjects` セクションに記述してください
+
+---
+
+### 7. `list_related_projects` - 関連プロジェクト一覧
+
+設定されている関連プロジェクトの一覧を取得します。
+
+**パラメータ**: なし
+
+**使用例**:
+
+```
+ユーザー: 関連プロジェクトを一覧表示して
+
+Claude: [list_related_projectsツールを使用]
+```
+
+**レスポンス例**:
+
+```
+関連プロジェクト
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. ai-agent-prompts
+   URL: http://localhost:24281
+   説明: エージェントプロンプト集
+   ソース: 設定ファイル
+
+2. other-project
+   URL: http://localhost:24282
+   説明: -
+   ソース: 一時追加
+```
+
+---
+
 ## 実践的な使用例
 
 ### 例1: 特定トピックの調査
@@ -328,6 +433,35 @@ Claude: Dirty管理に関する文書を検索します。
 Dirty管理について、3つの観点からまとめます：
 ...
 ```
+
+### 例4: 関連プロジェクトの検索
+
+```
+ユーザー: ai-agent-promptsプロジェクトのエージェント設計について調べて
+
+Claude: まず、ai-agent-promptsプロジェクトを検索対象に追加します。
+
+[add_related_projectツール]
+name: "ai-agent-prompts"
+url: "http://localhost:24281"
+
+追加しました。それでは検索します。
+
+[searchツール]
+query: "エージェント設計"
+project: "ai-agent-prompts"
+limit: 5
+
+検索結果:
+1. recipes/agent-design/README.md - エージェント設計パターン
+2. docs/principles.md - 設計原則
+...
+```
+
+**関連プロジェクト検索のポイント**:
+1. `add_related_project` で関連プロジェクトを追加（または設定ファイルに記述）
+2. 関連プロジェクトのサーバを `search-docs server start` で起動
+3. `search`, `get_document`, `get_outline` の `project` パラメータで指定
 
 ---
 

--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -6,43 +6,42 @@ search-docs は複数のプロセスとコンポーネントにまたがる状�
 
 | 層 | 状態 | 値 | 所在 |
 |----|------|-----|------|
-| MCP | SystemState | NOT_CONFIGURED / CONFIGURED_SERVER_DOWN / RUNNING | MCPサーバプロセス |
-| Watcher | writerState | sleeping / claiming / watching | JSON-RPCサーバプロセス |
-| DB | connectionState | disconnected / connecting / initializing_model / ready / error | JSON-RPCサーバプロセス |
-| Worker | IndexWorker | isRunning × isProcessing | JSON-RPCサーバプロセス |
-| Worker | FileWatcher | 起動 / 停止 | JSON-RPCサーバプロセス |
-| Worker | StartupSyncWorker | isSyncing | JSON-RPCサーバプロセス |
-| Embedding | EmbeddingServerProcess | detecting → ready / error | JSON-RPCサーバプロセス |
+| MCP | SystemState | NOT_CONFIGURED / RUNNING | MCPサーバプロセス |
+| Watcher | writerState | sleeping / claiming / watching | MCPサーバプロセス（in-process WatcherProcess） |
+| DB | connectionState | disconnected / connecting / initializing_model / ready / error | MCPサーバプロセス（in-process DBEngine） |
+| Worker | IndexWorker | isRunning × isProcessing | MCPサーバプロセス（in-process WatcherProcess） |
+| Worker | FileWatcher | 起動 / 停止 | MCPサーバプロセス（in-process WatcherProcess） |
+| Worker | StartupSyncWorker | isSyncing | MCPサーバプロセス（in-process WatcherProcess） |
+| Embedding | EmbeddingServerProcess | detecting → ready / error | MCPサーバプロセス（in-process） |
 
 ## プロセス構成と状態の所在
 
 ```
 MCPサーバプロセス (stdio)
 │  SystemState を管理
-│  ServerManager でJSON-RPCサーバへの接続を管理
+│  ServerManager で関連プロジェクトへのURL接続を管理
 │
-│  ── JSON-RPC ──▶  JSON-RPCサーバプロセス (HTTP)
-│                   │
-│                   ├─ EmbeddingServerProcess (最初に起動)
-│                   │    外部検出 or ローカルspawn → URL確定
-│                   │
-│                   ├─ SearchDocsServer (読み取り専用)
-│                   │    connectionState を参照
-│                   │    GetStatusResponse を構築
-│                   │
-│                   ├─ WatcherProcess
-│                   │    writerState を管理
-│                   │    │
-│                   │    ├─ DBEngine (connectionState)
-│                   │    ├─ FileWatcher (subscription)
-│                   │    ├─ IndexWorker (isRunning, isProcessing)
-│                   │    └─ StartupSyncWorker (isSyncing)
-│                   │
-│                   └─ DBEngine ──spawn──▶ Pythonワーカー (子プロセス)
-│                                          └─ Embeddingサーバ (HTTP, 共有可能)
+├─ in-process: SearchDocsServer (read-only)
+│   connectionState を参照
+│   GetStatusResponse を構築
+│
+├─ in-process: WatcherProcess (write)
+│   writerState を管理
+│   │
+│   ├─ FileWatcher (subscription, master時のみ起動)
+│   ├─ IndexWorker (isRunning, isProcessing, master時のみ起動)
+│   └─ StartupSyncWorker (isSyncing, master時のみ起動)
+│
+├─ in-process: DBEngine
+│   connectionState を管理
+│   └─ subprocess: Pythonワーカー
+│
+└─ in-process: EmbeddingServerProcess
+    外部検出 or ローカルspawn → URL確定
+    └─ subprocess: Embeddingサーバ (HTTP, 共有可能)
 ```
 
-MCPサーバとJSON-RPCサーバは別プロセスとして動作する。MCPサーバはJSON-RPCサーバの起動・停止を管理し、JSON-RPC経由で状態を取得する。
+MCPサーバは**SearchDocsServerをin-processで直接保持**します。HTTPデーモンのspawnは不要です。`server start` CLIコマンドは引き続きHTTPサーバとしてSearchDocsServerをexposeする用途で存続します。
 
 ## 各状態の詳細
 
@@ -51,29 +50,27 @@ MCPサーバとJSON-RPCサーバは別プロセスとして動作する。MCPサ
 MCPサーバが自身の動作モードを決定するための状態。
 
 ```
-                      ┌──────────────────┐
-                      │  NOT_CONFIGURED  │  設定ファイルなし
-                      └──────┬───────────┘
-                             │ init実行
-                             ▼
-┌──────────────────────────────────────────┐
-│         CONFIGURED_SERVER_DOWN           │  設定あり、サーバ未起動
-│  （自動起動を試みる一時的な状態）          │
-└──────────────────┬───────────────────────┘
-                   │ healthCheck成功
-                   ▼
-              ┌─────────┐
-              │ RUNNING  │  サーバ稼働中
-              └─────────┘
+┌──────────────────┐
+│  NOT_CONFIGURED  │  設定ファイルなし
+└──────┬───────────┘
+       │ init実行
+       │ (設定ファイル作成)
+       ▼
+  ┌─────────┐
+  │ RUNNING  │  設定あり、サーバ稼働中（in-process）
+  └─────────┘
 ```
 
-**定義**: `packages/mcp-server/src/state.ts` L11
+**定義**: `packages/mcp-server/src/state.ts` L14
 
 - **NOT_CONFIGURED**: `ConfigLoader.resolve()` で設定ファイルが見つからない
-- **CONFIGURED_SERVER_DOWN**: 設定ファイルは存在するが `healthCheck()` が失敗。MCPサーバ起動時に自動起動を試みるため、通常は一時的な状態
-- **RUNNING**: `healthCheck()` が成功。各ツールが利用可能
+- **RUNNING**: 設定ファイルが存在し、in-processでSearchDocsServerが稼働中
 
-**判定**: `detectSystemState(cwd)` が起動時と `refreshSystemState()` 呼び出し時に実行。
+**判定**: `detectSystemState(cwd)` が起動時に実行。設定ファイルが存在する場合、`createService()` でin-processのSearchDocsServerインスタンスを作成し、RUNNING状態になります。
+
+**変更点（v1.9.0以降）**:
+- `CONFIGURED_SERVER_DOWN` 状態を削除（in-process化により不要）
+- 設定ファイルが存在すればin-processで起動するため、サーバダウン状態は発生しません
 
 ### 2. writerState（Watcher層）
 
@@ -196,24 +193,20 @@ bin/server.ts が最初に起動するコンポーネント。Embeddingサーバ
 
 MCPサーバ起動
 │
-├─ detectSystemState()
-│    設定ファイル確認 → healthCheck
-│    → CONFIGURED_SERVER_DOWN
+├─ detectSystemState(cwd)
+│    設定ファイル確認
+│    → NOT_CONFIGURED または RUNNING準備
 │
-├─ serverManager.startServer()
-│    CLI経由でJSON-RPCサーバをspawn
-│    healthCheck待ち（最大30秒）
-│
-│    JSON-RPCサーバ起動
+├─ (RUNNING準備の場合) createService()
 │    │
 │    ├─ EmbeddingServerProcess.start()
 │    │    外部検出 or ローカルspawn → URL確定
 │    │
-│    ├─ SearchDocsServer.start()
+│    ├─ SearchDocsServer作成・起動
 │    │    DBEngine.connect(embeddingUrl) [バックグラウンド]
 │    │    connectionState: disconnected → connecting
 │    │
-│    ├─ WatcherProcess.start()
+│    ├─ WatcherProcess作成・起動
 │    │    DBEngine.waitForConnection() 待ち
 │    │
 │    │    ... Pythonワーカー起動 ...
@@ -224,17 +217,22 @@ MCPサーバ起動
 │    │    checkAndClaimMaster()
 │    │    writerState: sleeping → claiming → watching
 │    │
+│    │    (master獲得の場合)
 │    │    FileWatcher.start()
 │    │    IndexWorker.start()
 │    │    StartupSyncWorker.startSync()
 │    │
-│    └─ healthCheck応答可能に
+│    └─ ServiceInstances返却
 │
-├─ detectSystemState() 再実行
-│    → RUNNING
+├─ SystemState: RUNNING
 │
-└─ MCPツール利用可能
+└─ MCPツール利用可能（in-processで即座に実行）
 ```
+
+**変更点（v1.9.0以降）**:
+- HTTPデーモンのspawnが不要に（in-process化）
+- healthCheck待ちが不要に（同一プロセス内で直接実行）
+- 起動が高速化（プロセス間通信のオーバーヘッドなし）
 
 ## 状態公開API
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -17,6 +17,7 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
   JsonRpcError,
+  SearchDocsService,
 } from '@search-docs/types';
 
 /**
@@ -48,7 +49,7 @@ export class JsonRpcClientError extends Error {
  *
  * HTTPサーバとJSON-RPC 2.0で通信し、検索・インデックス操作を提供
  */
-export class SearchDocsClient {
+export class SearchDocsClient implements SearchDocsService {
   private baseUrl: string;
   private timeout: number;
   private requestId = 0;

--- a/packages/db-engine/pyproject.toml
+++ b/packages/db-engine/pyproject.toml
@@ -4,27 +4,21 @@ version = "0.1.0"
 description = "search-docs LanceDB Vector検索エンジン"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "lancedb>=0.5.0",
-    "pyarrow>=14.0.0",
-    "pandas>=2.0.0",
-    "numpy>=1.24.0",
-    "onnxruntime>=1.20.0",
-    "transformers>=4.48.0",
-    "huggingface-hub>=0.27.0",
-    "protobuf>=4.0.0",
-    "sentencepiece>=0.1.99",
-    "pytest>=7.0.0",
-    "psutil>=5.9.0",
-    "duckdb>=0.9.0",
-    "pylance>=0.9.0",
+    "lancedb==0.30.2",
+    "pylance==0.39.0",
+    "pyarrow==22.0.0",
+    "pandas==2.3.3",
+    "numpy==2.3.5",
+    "onnxruntime==1.20.0",
+    "transformers==4.57.1",
+    "huggingface-hub==0.36.0",
+    "protobuf==6.33.1",
+    "sentencepiece==0.2.1",
+    "pytest==9.0.1",
+    "psutil==7.1.3",
 ]
 
 [project.optional-dependencies]
-# レガシー PyTorch サポート
-torch = [
-    "torch>=2.0.0",
-    "sentence-transformers>=5.0.0",
-]
 # GPU版（ONNX Runtime + CUDA）
 gpu = [
     "onnxruntime-gpu>=1.20.0",

--- a/packages/db-engine/src/python/worker.py
+++ b/packages/db-engine/src/python/worker.py
@@ -1100,9 +1100,9 @@ class SearchDocsWorker:
         # Dirty件数（count_rows()で効率的にカウント）
         dirty_count = table.count_rows(filter="is_dirty = true")
 
-        # ユニークな文書数を取得（scanner直アクセスでベクトルカラムを除外）
+        # ユニークな文書数を取得（Lance Dataset APIでベクトルカラムを除外）
         try:
-            paths = table._dataset.scanner(columns=["document_path"]).to_table()
+            paths = table.to_lance().scanner(columns=["document_path"]).to_table()
             total_documents = len(paths.column("document_path").unique())
         except Exception as e:
             sys.stderr.write(f"Warning: Could not get unique document count: {e}\n")

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -29,6 +29,9 @@
     "@modelcontextprotocol/sdk": "1.20.2",
     "@search-docs/cli": "workspace:*",
     "@search-docs/client": "workspace:*",
+    "@search-docs/db-engine": "workspace:*",
+    "@search-docs/server": "workspace:*",
+    "@search-docs/storage": "workspace:*",
     "@search-docs/types": "workspace:*",
     "commander": "12.1.0",
     "zod": "3.25.76"

--- a/packages/mcp-server/src/__tests__/server-manager-related.test.ts
+++ b/packages/mcp-server/src/__tests__/server-manager-related.test.ts
@@ -6,46 +6,40 @@ import { describe, it, expect } from 'vitest';
 import { ServerManager } from '../server-manager.js';
 
 describe('ServerManager.getAllRelatedProjects', () => {
-  it('config由来のdirを絶対パスに解決する', () => {
+  it('config由来のプロジェクトをそのまま返す', () => {
     const manager = new ServerManager();
 
-    const result = manager.getAllRelatedProjects(
-      {
-        'project-a': { dir: '../other-project', description: 'テスト' },
-      },
-      '/home/user/main-project/.search-docs.json'
-    );
+    const result = manager.getAllRelatedProjects({
+      'project-a': { url: 'http://localhost:3000', description: 'テスト' },
+    });
 
     expect(result['project-a']).toBeDefined();
-    expect(result['project-a'].dir).toBe('/home/user/other-project');
+    expect(result['project-a'].url).toBe('http://localhost:3000');
     expect(result['project-a'].description).toBe('テスト');
   });
 
   it('一時追加プロジェクトはそのまま返す', () => {
     const manager = new ServerManager();
     manager.addTemporaryRelatedProject('temp-project', {
-      dir: '/absolute/path/to/project',
+      url: 'http://localhost:4000',
       description: '一時追加',
     });
 
     const result = manager.getAllRelatedProjects();
 
     expect(result['temp-project']).toBeDefined();
-    expect(result['temp-project'].dir).toBe('/absolute/path/to/project');
+    expect(result['temp-project'].url).toBe('http://localhost:4000');
   });
 
   it('config由来と一時追加をマージして返す', () => {
     const manager = new ServerManager();
     manager.addTemporaryRelatedProject('temp-project', {
-      dir: '/tmp/temp',
+      url: 'http://localhost:5000',
     });
 
-    const result = manager.getAllRelatedProjects(
-      {
-        'config-project': { dir: '../config-proj' },
-      },
-      '/home/user/main/.search-docs.json'
-    );
+    const result = manager.getAllRelatedProjects({
+      'config-project': { url: 'http://localhost:6000' },
+    });
 
     expect(Object.keys(result)).toHaveLength(2);
     expect(result['config-project']).toBeDefined();
@@ -55,32 +49,16 @@ describe('ServerManager.getAllRelatedProjects', () => {
   it('同名の場合は一時追加が優先される', () => {
     const manager = new ServerManager();
     manager.addTemporaryRelatedProject('project-a', {
-      dir: '/tmp/temporary',
+      url: 'http://localhost:7000',
       description: '一時追加版',
     });
 
-    const result = manager.getAllRelatedProjects(
-      {
-        'project-a': { dir: '../config-version', description: 'config版' },
-      },
-      '/home/user/main/.search-docs.json'
-    );
+    const result = manager.getAllRelatedProjects({
+      'project-a': { url: 'http://localhost:8000', description: 'config版' },
+    });
 
-    expect(result['project-a'].dir).toBe('/tmp/temporary');
+    expect(result['project-a'].url).toBe('http://localhost:7000');
     expect(result['project-a'].description).toBe('一時追加版');
-  });
-
-  it('configPathなしの場合、config由来のプロジェクトは含まれない', () => {
-    const manager = new ServerManager();
-    manager.addTemporaryRelatedProject('temp', { dir: '/tmp/temp' });
-
-    const result = manager.getAllRelatedProjects(
-      { 'config-proj': { dir: '../somewhere' } },
-      undefined
-    );
-
-    expect(result['config-proj']).toBeUndefined();
-    expect(result['temp']).toBeDefined();
   });
 
   it('両方空の場合は空オブジェクトを返す', () => {

--- a/packages/mcp-server/src/__tests__/state.test.ts
+++ b/packages/mcp-server/src/__tests__/state.test.ts
@@ -6,11 +6,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { detectSystemState, getStateErrorMessage } from '../state.js';
 import type { SystemState } from '../state.js';
 import { ConfigLoader } from '@search-docs/types';
-import { SearchDocsClient } from '@search-docs/client';
 
 // モック
 vi.mock('@search-docs/types');
-vi.mock('@search-docs/client');
 
 describe('state', () => {
   describe('detectSystemState', () => {
@@ -46,7 +44,7 @@ describe('state', () => {
       expect(result.projectRoot).toBe('/test/project');
     });
 
-    it('設定ファイルがあるがサーバが停止中の場合、CONFIGURED_SERVER_DOWNを返す', async () => {
+    it('設定ファイルがある場合、RUNNINGを返す', async () => {
       const mockConfig = {
         version: '1.0',
         server: {
@@ -62,49 +60,6 @@ describe('state', () => {
         configPath: '/test/project/.search-docs.json',
         projectRoot: '/test/project',
       });
-
-      // SearchDocsClient.healthCheck がエラーを投げる（サーバ停止中）
-      const mockHealthCheck = vi.fn().mockRejectedValue(new Error('Connection refused'));
-      vi.mocked(SearchDocsClient).mockImplementation(
-        class {
-          healthCheck = mockHealthCheck;
-        } as any
-      );
-
-      const result = await detectSystemState('/test/project');
-
-      expect(result.state).toBe('CONFIGURED_SERVER_DOWN');
-      expect(result.config).toBe(mockConfig);
-      expect(result.configPath).toBe('/test/project/.search-docs.json');
-      expect(result.projectRoot).toBe('/test/project');
-      expect(result.serverUrl).toBe('http://localhost:24280');
-      expect(result.client).toBeUndefined();
-    });
-
-    it('設定ファイルがありサーバが稼働中の場合、RUNNINGを返す', async () => {
-      const mockConfig = {
-        version: '1.0',
-        server: {
-          host: 'localhost',
-          port: 24280,
-          protocol: 'json-rpc' as const,
-        },
-      } as any;
-
-      // ConfigLoader.resolve が設定を返す
-      vi.mocked(ConfigLoader.resolve).mockResolvedValue({
-        config: mockConfig,
-        configPath: '/test/project/.search-docs.json',
-        projectRoot: '/test/project',
-      });
-
-      // SearchDocsClient.healthCheck が成功（サーバ稼働中）
-      const mockHealthCheck = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(SearchDocsClient).mockImplementation(
-        class {
-          healthCheck = mockHealthCheck;
-        } as any
-      );
 
       const result = await detectSystemState('/test/project');
 
@@ -112,8 +67,7 @@ describe('state', () => {
       expect(result.config).toBe(mockConfig);
       expect(result.configPath).toBe('/test/project/.search-docs.json');
       expect(result.projectRoot).toBe('/test/project');
-      expect(result.serverUrl).toBe('http://localhost:24280');
-      expect(result.client).toBeDefined();
+      expect(result.service).toBeUndefined();
     });
   });
 
@@ -125,13 +79,6 @@ describe('state', () => {
       expect(message).toContain('セットアップされていません');
       expect(message).toContain('init');
       expect(message).toContain('add_related_project');
-    });
-
-    it('CONFIGURED_SERVER_DOWN状態のエラーメッセージを返す', () => {
-      const message = getStateErrorMessage('CONFIGURED_SERVER_DOWN', '検索');
-
-      expect(message).toContain('検索を実行できません');
-      expect(message).toContain('自動起動中です');
     });
 
     it('RUNNING状態のエラーメッセージを返す', () => {
@@ -154,13 +101,6 @@ describe('state', () => {
 
       expect(message).toContain('検索を実行できません');
       expect(message).not.toContain('利用可能な関連プロジェクト');
-    });
-
-    it('CONFIGURED_SERVER_DOWN状態で関連プロジェクト名を表示する', () => {
-      const message = getStateErrorMessage('CONFIGURED_SERVER_DOWN', '検索', ['my-project']);
-
-      expect(message).toContain('検索を実行できません');
-      expect(message).toContain('my-project');
     });
   });
 });

--- a/packages/mcp-server/src/server-manager.ts
+++ b/packages/mcp-server/src/server-manager.ts
@@ -1,21 +1,9 @@
 /**
- * サーバ自動起動マネージャー
+ * サーバマネージャー（関連プロジェクトURL接続管理）
  */
 
-import { spawn, type ChildProcess } from 'child_process';
-import * as path from 'path';
-import * as fs from 'fs/promises';
 import { SearchDocsClient } from '@search-docs/client';
 import type { RelatedProjectConfig } from '@search-docs/types';
-import { ConfigLoader } from '@search-docs/types';
-
-/**
- * サーバプロセス情報
- */
-interface ServerProcess {
-  process: ChildProcess;
-  port: number;
-}
 
 /**
  * サーバ情報（複数プロジェクト対応）
@@ -28,232 +16,15 @@ interface ServerInfo {
 }
 
 /**
- * サーバマネージャー（複数プロジェクト対応）
+ * サーバマネージャー（関連プロジェクトURL接続管理）
  */
 export class ServerManager {
-  private serverProcess: ServerProcess | null = null;
-
   // 複数プロジェクトのサーバを管理
   private servers: Map<string, ServerInfo> = new Map();
 
   // 一時的な関連プロジェクト（設定ファイル未保存）
   private temporaryRelatedProjects: Map<string, RelatedProjectConfig> = new Map();
 
-  /**
-   * @search-docs/cliパッケージのエントリポイントを解決
-   */
-  private async resolveCliPath(): Promise<string> {
-    try {
-      // import.meta.resolve()でパスを解決
-      // これはパッケージのエントリポイント（package.jsonのmainフィールド）を返す
-      const cliPackage = import.meta.resolve('@search-docs/cli');
-
-      // file:// プロトコルを削除してファイルパスに変換
-      const cliEntryPoint = cliPackage.replace(/^file:\/\//, '');
-
-      // ファイルが存在するか確認
-      await fs.access(cliEntryPoint);
-
-      return cliEntryPoint;
-    } catch (error) {
-      throw new Error(
-        `Failed to resolve @search-docs/cli package: ${(error as Error).message}\n` +
-        'Please ensure @search-docs/cli is installed.'
-      );
-    }
-  }
-
-  /**
-   * サーバを起動（デーモンモード）
-   */
-  async startServer(projectDir: string, port: number, configPath?: string): Promise<void> {
-    console.error('[mcp-server] ========================================');
-    console.error('[mcp-server] Starting search-docs server...');
-    console.error('[mcp-server] Input parameters:');
-    console.error(`[mcp-server]   - projectDir: ${projectDir}`);
-    console.error(`[mcp-server]   - port: ${port}`);
-    console.error(`[mcp-server]   - configPath: ${configPath || '(not provided)'}`);
-
-    try {
-      // CLIのエントリポイントを解決
-      const cliPath = await this.resolveCliPath();
-      console.error(`[mcp-server] CLI path resolved: ${cliPath}`);
-
-      // サーバ起動コマンドを構築（デーモンモード）
-      const args = ['server', 'start', '--port', port.toString()];
-
-      if (configPath) {
-        args.push('--config', configPath);
-      }
-
-      console.error('[mcp-server] Spawn parameters:');
-      console.error(`[mcp-server]   - command: node`);
-      console.error(`[mcp-server]   - args: ${JSON.stringify([cliPath, ...args])}`);
-      console.error(`[mcp-server]   - cwd: ${projectDir}`);
-      console.error(`[mcp-server]   - stdio: ['ignore', 'pipe', 'pipe']`);
-      console.error(`[mcp-server]   - detached: false`);
-
-      // サーバを起動（デーモンモード）
-      const serverProcess = spawn(
-        'node',
-        [cliPath, ...args],
-        {
-          cwd: projectDir, // プロジェクトディレクトリで実行
-          stdio: ['ignore', 'pipe', 'pipe'], // stdin無視, stdout/stderrキャプチャ
-          detached: false,
-        }
-      );
-
-      console.error(`[mcp-server] Process spawned with PID: ${serverProcess.pid || '(unknown)'}`);
-
-      // エラーハンドリング
-      serverProcess.on('error', (error) => {
-        console.error(`[mcp-server] Server process error: ${error.message}`);
-      });
-
-      // 標準出力をログ
-      serverProcess.stdout?.on('data', (data: Buffer) => {
-        console.error(`[server] ${data.toString().trim()}`);
-      });
-
-      // 標準エラー出力をログ
-      serverProcess.stderr?.on('data', (data: Buffer) => {
-        console.error(`[server] ${data.toString().trim()}`);
-      });
-
-      // プロセス終了時
-      serverProcess.on('exit', (code, signal) => {
-        console.error(`[mcp-server] Server launcher exited: code=${code}, signal=${signal}`);
-      });
-
-      // デーモンモードなので、起動プロセスは即座に終了する
-      // 実際のサーバプロセスは別プロセスとして起動される
-      this.serverProcess = {
-        process: serverProcess,
-        port,
-      };
-
-      // デーモンモードでは起動プロセスが即座に終了するため、
-      // 実際のサーバプロセスが起動完了するまで待機する
-      console.error('[mcp-server] Waiting for server to start...');
-
-      // サーバのヘルスチェックを行う（最大30秒待機）
-      const serverUrl = `http://127.0.0.1:${port}`;
-      const client = new SearchDocsClient({ baseUrl: serverUrl });
-      const maxWaitTime = 30000; // 30秒
-      const checkInterval = 1000; // 1秒
-      let waited = 0;
-      let serverReady = false;
-
-      console.error(`[mcp-server] Health check target: ${serverUrl}`);
-      console.error(`[mcp-server] Max wait time: ${maxWaitTime}ms, check interval: ${checkInterval}ms`);
-
-      while (waited < maxWaitTime) {
-        try {
-          console.error(`[mcp-server] Health check attempt (waited: ${waited}ms)...`);
-          await client.healthCheck();
-          serverReady = true;
-          console.error('[mcp-server] ✓ Server is ready (health check passed)');
-          break;
-        } catch (error) {
-          // サーバがまだ起動していない、待機を続ける
-          console.error(`[mcp-server]   Health check failed: ${(error as Error).message}`);
-          await new Promise(resolve => setTimeout(resolve, checkInterval));
-          waited += checkInterval;
-        }
-      }
-
-      if (!serverReady) {
-        console.error('[mcp-server] ✗ Health check timeout after 30 seconds');
-        throw new Error('Server failed to start within 30 seconds');
-      }
-
-      // PIDファイルの作成を確認
-      const pidFilePath = path.join(projectDir, '.search-docs', 'server.pid');
-      console.error(`[mcp-server] Checking PID file at: ${pidFilePath}`);
-      try {
-        await fs.access(pidFilePath);
-        const pidContent = await fs.readFile(pidFilePath, 'utf-8');
-        console.error('[mcp-server] ✓ PID file confirmed');
-        console.error(`[mcp-server]   PID file content: ${pidContent.substring(0, 200)}...`);
-      } catch (error) {
-        console.error(`[mcp-server] ✗ Warning: PID file not found: ${(error as Error).message}`);
-      }
-
-      console.error('[mcp-server] Server started successfully (daemon mode)');
-      console.error('[mcp-server] ========================================');
-    } catch (error) {
-      throw new Error(`Failed to start server: ${(error as Error).message}`);
-    }
-  }
-
-  /**
-   * サーバを停止
-   */
-  stopServer(): void {
-    if (this.serverProcess) {
-      console.error('[mcp-server] Stopping server...');
-      this.serverProcess.process.kill('SIGTERM');
-      this.serverProcess = null;
-    }
-  }
-
-  /**
-   * クリーンアップ（プロセス終了時）
-   */
-  cleanup(): void {
-    this.stopServer();
-  }
-
-  /**
-   * プロジェクトのサーバを取得または起動
-   * @param projectName プロジェクト名（キャッシュキー）
-   * @param projectRoot プロジェクトルート
-   * @param port ポート番号
-   * @param configPath 設定ファイルパス（オプション）
-   * @returns SearchDocsClient
-   */
-  async getOrStartServer(
-    projectName: string,
-    projectRoot: string,
-    port: number,
-    configPath?: string
-  ): Promise<SearchDocsClient> {
-    // キャッシュチェック
-    const cached = this.servers.get(projectName);
-    if (cached) {
-      // ヘルスチェック
-      try {
-        await cached.client.healthCheck();
-        console.error(`[mcp-server] Using cached client for project: ${projectName}`);
-        return cached.client;
-      } catch (_error) {
-        // サーバが停止している、キャッシュをクリア
-        console.error(`[mcp-server] Cached server for ${projectName} is down, restarting...`);
-        this.servers.delete(projectName);
-      }
-    }
-
-    // サーバを起動
-    console.error(`[mcp-server] Starting server for project: ${projectName}`);
-    await this.startServer(projectRoot, port, configPath);
-
-    // クライアントを作成してキャッシュ
-    const serverUrl = `http://127.0.0.1:${port}`;
-    const client = new SearchDocsClient({ baseUrl: serverUrl });
-
-    const serverInfo: ServerInfo = {
-      client,
-      port,
-      projectRoot,
-      projectName,
-    };
-
-    this.servers.set(projectName, serverInfo);
-    console.error(`[mcp-server] Server cached for project: ${projectName}`);
-
-    return client;
-  }
 
   /**
    * 起動済みプロジェクトのサーバクライアントを取得
@@ -276,38 +47,6 @@ export class ServerManager {
     }
   }
 
-  /**
-   * 関連プロジェクトのサーバを停止
-   * @param projectName プロジェクト名
-   */
-  async stopRelatedServer(projectName: string): Promise<void> {
-    const serverInfo = this.servers.get(projectName);
-    if (!serverInfo) {
-      throw new Error(`プロジェクト "${projectName}" のサーバは起動していません。`);
-    }
-
-    // URL接続のサーバは外部管理なので停止処理をスキップ
-    if (serverInfo.projectRoot === '') {
-      console.error(`[mcp-server] Skipping stop for URL-connected project: ${projectName}`);
-      this.servers.delete(projectName);
-      return;
-    }
-
-    // CLIのstopServer経由で停止
-    const { stopServer } = await import('@search-docs/cli/commands/server/stop');
-    const { configPath } = await ConfigLoader.resolve({
-      cwd: serverInfo.projectRoot,
-      traverseUp: false,
-    });
-    await stopServer({
-      config: configPath ?? undefined,
-      cwd: serverInfo.projectRoot,
-    });
-
-    // キャッシュから削除
-    this.servers.delete(projectName);
-    console.error(`[mcp-server] Stopped server for project: ${projectName}`);
-  }
 
   /**
    * すべてのサーバ情報を取得
@@ -317,9 +56,9 @@ export class ServerManager {
   }
 
   /**
-   * 関連プロジェクトのサーバに接続（URL指定のみ）
+   * 関連プロジェクトへのURL接続を確立
    */
-  async connectRelatedServer(
+  async connectRelatedProject(
     projectName: string,
     allRelated: Record<string, RelatedProjectConfig>
   ): Promise<SearchDocsClient> {
@@ -338,9 +77,7 @@ export class ServerManager {
 
     if (!relatedConfig.url) {
       throw new Error(
-        `関連プロジェクト "${projectName}" にはサーバURLが設定されていません。\n\n` +
-        `対象プロジェクトで search-docs server start を実行してから、\n` +
-        `add_related_project で url を指定して追加してください。`
+        `関連プロジェクト "${projectName}" の設定に "url" が必要です。`
       );
     }
 
@@ -354,7 +91,6 @@ export class ServerManager {
     } catch (error) {
       throw new Error(
         `関連プロジェクト "${projectName}" のサーバ (URL: ${relatedConfig.url}) に接続できません。\n` +
-        `対象プロジェクトで search-docs server start を実行してください。\n` +
         `エラー: ${(error as Error).message}`
       );
     }
@@ -380,31 +116,20 @@ export class ServerManager {
 
   /**
    * 設定ファイルと一時追加分をマージした関連プロジェクト一覧を取得
-   * 返却値のdirは全て絶対パスに解決済み（urlの場合はdirなし）
    */
   getAllRelatedProjects(
-    configRelated?: Record<string, RelatedProjectConfig>,
-    configPath?: string
+    configRelated?: Record<string, RelatedProjectConfig>
   ): Record<string, RelatedProjectConfig> {
     const merged: Record<string, RelatedProjectConfig> = {};
 
-    // 設定ファイルからの関連プロジェクト（相対パスを絶対パスに解決）
-    if (configRelated && configPath) {
-      const baseDir = path.dirname(configPath);
+    // 設定ファイルからの関連プロジェクト
+    if (configRelated) {
       for (const [name, config] of Object.entries(configRelated)) {
-        // URL指定の場合はdirの解決不要
-        if (config.url) {
-          merged[name] = { ...config };
-        } else if (config.dir) {
-          merged[name] = {
-            ...config,
-            dir: path.resolve(baseDir, config.dir),
-          };
-        }
+        merged[name] = { ...config };
       }
     }
 
-    // 一時追加分（既に絶対パス、同名がある場合は一時追加分が優先）
+    // 一時追加分（同名がある場合は一時追加分が優先）
     for (const [name, config] of this.temporaryRelatedProjects) {
       merged[name] = config;
     }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,7 +10,7 @@ import { Command } from 'commander';
 import { createRequire } from 'module';
 import * as path from 'path';
 
-import { detectSystemState, type SystemState } from './state.js';
+import { detectSystemState, createService, stopService, type SystemState, type ServiceInstances } from './state.js';
 import { ServerManager } from './server-manager.js';
 import {
   registerInitTool,
@@ -137,38 +137,25 @@ async function main() {
   debugLog(`Working directory: ${cwd}`);
 
   // システム状態を判定
-  let systemState = await detectSystemState(cwd);
+  const systemState = await detectSystemState(cwd);
+  let serviceInstances: ServiceInstances | null = null;
+
   debugLog('='.repeat(60));
   debugLog(`System state detected: ${systemState.state}`);
   debugLog(`Project root: ${systemState.projectRoot}`);
   debugLog(`Config exists: ${systemState.config ? 'YES' : 'NO'}`);
   debugLog(`Config path: ${systemState.configPath || '(none)'}`);
 
-  // CONFIGURED_SERVER_DOWNの場合、サーバを自動起動
-  debugLog(`Checking auto-start condition: state === CONFIGURED_SERVER_DOWN && config exists`);
-  debugLog(`  - state === CONFIGURED_SERVER_DOWN: ${systemState.state === 'CONFIGURED_SERVER_DOWN'}`);
-  debugLog(`  - config exists: ${!!systemState.config}`);
-
-  if (systemState.state === 'CONFIGURED_SERVER_DOWN' && systemState.config) {
-    debugLog('✓ Config exists, attempting auto-start...');
-
-    const serverManager = new ServerManager();
+  // 設定があればin-processでサービスを起動
+  if (systemState.state === 'RUNNING' && systemState.config) {
+    debugLog('Creating in-process service...');
     try {
-      debugLog(`Auto-start params: projectRoot=${systemState.projectRoot}, port=${systemState.config.server.port}, configPath=${systemState.configPath}`);
-      await serverManager.startServer(
-        systemState.projectRoot,
-        systemState.config.server.port,
-        systemState.configPath
-      );
-
-      // 自動起動成功、状態を再判定
-      systemState = await detectSystemState(cwd);
-      debugLog(`System state after auto-start: ${systemState.state}`);
-    } catch (startError) {
-      debugLog(`Auto-start failed: ${(startError as Error).message}`);
+      serviceInstances = await createService(systemState.config, systemState.projectRoot, VERSION);
+      systemState.service = serviceInstances.service;
+      debugLog('✓ In-process service created successfully');
+    } catch (error) {
+      debugLog(`✗ Service creation failed: ${(error as Error).message}`);
     }
-  } else {
-    debugLog('✗ Auto-start condition not met, skipping auto-start');
   }
   debugLog('='.repeat(60));
 
@@ -190,9 +177,28 @@ async function main() {
 
   // システム状態を再検出する関数
   const refreshSystemState = async () => {
+    // 既存サービスを停止
+    if (serviceInstances) {
+      debugLog('Stopping existing service before refresh...');
+      await stopService(serviceInstances);
+      serviceInstances = null;
+    }
+
     const newState = await detectSystemState(cwd);
     // systemStateオブジェクトのプロパティを更新
     Object.assign(systemState, newState);
+
+    // 設定があればサービスを再作成
+    if (systemState.state === 'RUNNING' && systemState.config) {
+      try {
+        serviceInstances = await createService(systemState.config, systemState.projectRoot, VERSION);
+        systemState.service = serviceInstances.service;
+        debugLog('✓ Service recreated after refresh');
+      } catch (error) {
+        debugLog(`✗ Service recreation failed: ${(error as Error).message}`);
+      }
+    }
+
     debugLog(`System state refreshed: ${systemState.state}`);
 
     // ツールの有効/無効を更新
@@ -222,6 +228,18 @@ async function main() {
 
   // 初期状態に応じてツールの有効/無効を設定
   updateToolAvailability(systemState.state, toolHandles);
+
+  // プロセス終了時のクリーンアップ
+  const cleanup = async () => {
+    debugLog('Cleaning up...');
+    if (serviceInstances) {
+      await stopService(serviceInstances);
+      serviceInstances = null;
+    }
+  };
+
+  process.on('SIGINT', () => void cleanup());
+  process.on('SIGTERM', () => void cleanup());
 
   // サーバの起動
   const transport = new StdioServerTransport();

--- a/packages/mcp-server/src/state.ts
+++ b/packages/mcp-server/src/state.ts
@@ -2,13 +2,16 @@
  * システム状態管理
  */
 
-import { SearchDocsClient } from '@search-docs/client';
-import { ConfigLoader, type SearchDocsConfig } from '@search-docs/types';
+import * as path from 'path';
+import { ConfigLoader, type SearchDocsConfig, type SearchDocsService } from '@search-docs/types';
+import { FileStorage } from '@search-docs/storage';
+import { DBEngine } from '@search-docs/db-engine';
+import { SearchDocsServer, WatcherProcess, EmbeddingServerProcess } from '@search-docs/server';
 
 /**
  * システム状態の種類
  */
-export type SystemState = 'NOT_CONFIGURED' | 'CONFIGURED_SERVER_DOWN' | 'RUNNING';
+export type SystemState = 'NOT_CONFIGURED' | 'RUNNING';
 
 /**
  * システム状態情報
@@ -22,10 +25,18 @@ export interface SystemStateInfo {
   configPath?: string;
   /** プロジェクトルート */
   projectRoot: string;
-  /** サーバURL（設定ファイルが存在する場合） */
-  serverUrl?: string;
-  /** クライアントインスタンス（サーバが稼働中の場合） */
-  client?: SearchDocsClient;
+  /** サービスインスタンス（サーバが稼働中の場合） */
+  service?: SearchDocsService;
+}
+
+/**
+ * サービスインスタンス群
+ */
+export interface ServiceInstances {
+  service: SearchDocsServer;
+  watcherProcess: WatcherProcess;
+  dbEngine: DBEngine;
+  embeddingServer: EmbeddingServerProcess;
 }
 
 /**
@@ -35,11 +46,8 @@ export interface SystemStateInfo {
  * @returns システム状態情報
  */
 export async function detectSystemState(cwd: string): Promise<SystemStateInfo> {
-  // 1. 設定ファイルの存在確認
-  let config: SearchDocsConfig | undefined;
-  let configPath: string | undefined;
-  let projectRoot: string;
-
+  // 設定ファイルの存在確認のみ行う
+  // サービスの作成は createService() で行う
   try {
     const result = await ConfigLoader.resolve({
       cwd,
@@ -58,9 +66,13 @@ export async function detectSystemState(cwd: string): Promise<SystemStateInfo> {
       };
     }
 
-    config = result.config;
-    configPath = result.configPath ?? undefined;
-    projectRoot = result.projectRoot;
+    // 設定ファイルあり
+    return {
+      state: 'RUNNING',
+      config: result.config,
+      configPath: result.configPath ?? undefined,
+      projectRoot: result.projectRoot,
+    };
   } catch (_error) {
     // 設定ファイル読み込みエラー
     return {
@@ -68,33 +80,69 @@ export async function detectSystemState(cwd: string): Promise<SystemStateInfo> {
       projectRoot: cwd,
     };
   }
+}
 
-  // 2. サーバのヘルスチェック
-  const serverUrl = `http://${config.server.host}:${config.server.port}`;
-  const client = new SearchDocsClient({ baseUrl: serverUrl });
+/**
+ * サービスインスタンスを作成
+ *
+ * @param config - 設定情報
+ * @param projectRoot - プロジェクトルート
+ * @param version - バージョン情報
+ * @returns サービスインスタンス群
+ */
+export async function createService(
+  config: SearchDocsConfig,
+  projectRoot: string,
+  version: string
+): Promise<ServiceInstances> {
+  // 1. EmbeddingServerProcess検出・起動
+  const embeddingServer = new EmbeddingServerProcess({
+    embeddingUrl: process.env.EMBEDDING_URL || config.indexing.embeddingUrl,
+    port: 24281,
+    runtime: 'onnx',
+    modelPath: process.env.SEARCH_DOCS_DOCKER_MODEL_PATH,
+    dimension: config.indexing.vectorDimension,
+  });
+  const embeddingUrl = await embeddingServer.start();
 
-  try {
-    await client.healthCheck();
+  // 2. FileStorage初期化
+  const storage = new FileStorage({
+    basePath: path.resolve(projectRoot, config.storage.documentsPath),
+  });
 
-    // サーバ稼働中
-    return {
-      state: 'RUNNING',
-      config,
-      configPath,
-      projectRoot,
-      serverUrl,
-      client,
-    };
-  } catch (_error) {
-    // サーバ停止中
-    return {
-      state: 'CONFIGURED_SERVER_DOWN',
-      config,
-      configPath,
-      projectRoot,
-      serverUrl,
-    };
-  }
+  // 3. DBEngine初期化
+  const dbEngine = new DBEngine({
+    dbPath: path.resolve(projectRoot, config.storage.indexPath),
+    embeddingUrl,
+    maxBatchTokens: config.worker.maxBatchTokens,
+    pythonMaxMemoryMB: config.worker.pythonMaxMemoryMB,
+    memoryCheckIntervalMs: config.worker.memoryCheckIntervalMs,
+    readOnly: false,
+  });
+
+  // 4. SearchDocsServer初期化
+  const service = new SearchDocsServer(config, storage, dbEngine, version);
+
+  // 5. WatcherProcess初期化・接続
+  const watcherProcess = new WatcherProcess(config, storage, dbEngine);
+  service.setWatcherProcess(watcherProcess);
+
+  // 6. 起動
+  service.start();
+  watcherProcess.start();
+
+  return { service, watcherProcess, dbEngine, embeddingServer };
+}
+
+/**
+ * サービスインスタンスを停止
+ *
+ * @param instances - サービスインスタンス群
+ */
+export async function stopService(instances: ServiceInstances): Promise<void> {
+  await instances.watcherProcess.stop();
+  instances.service.stop();
+  await instances.embeddingServer.stop();
 }
 
 /**
@@ -112,19 +160,6 @@ export function getStateErrorMessage(state: SystemState, action: string, related
         'セットアップ方法:\n' +
         '  - 設定ファイルを作成: init\n' +
         '  - 関連プロジェクトを追加: add_related_project\n';
-
-      if (relatedProjectNames && relatedProjectNames.length > 0) {
-        message += `\n利用可能な関連プロジェクト: ${relatedProjectNames.join(', ')}\n`;
-        message += '関連プロジェクトを検索するには project パラメータを指定してください。\n';
-      }
-
-      return message;
-    }
-
-    case 'CONFIGURED_SERVER_DOWN': {
-      let message =
-        `${action}を実行できません。search-docsサーバを自動起動中です。\n` +
-        'しばらくお待ちください。\n';
 
       if (relatedProjectNames && relatedProjectNames.length > 0) {
         message += `\n利用可能な関連プロジェクト: ${relatedProjectNames.join(', ')}\n`;

--- a/packages/mcp-server/src/tools/__tests__/index-status.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/index-status.test.ts
@@ -58,8 +58,7 @@ describe('index_status tool', () => {
       config: {} as any,
       configPath: '/test/.search-docs.json',
       projectRoot: '/test',
-      serverUrl: 'http://localhost:24280',
-      client: mockClient as any,
+      service: mockClient as any,
     };
 
     const context: ToolRegistrationContext = {
@@ -111,30 +110,7 @@ describe('index_status tool', () => {
     await expect(registeredTool.handler({})).rejects.toThrow('セットアップされていません');
   });
 
-  it('CONFIGURED_SERVER_DOWN状態の場合、エラーを返す', async () => {
-    const systemState: SystemStateInfo = {
-      state: 'CONFIGURED_SERVER_DOWN',
-      config: {} as any,
-      configPath: '/test/.search-docs.json',
-      projectRoot: '/test',
-      serverUrl: 'http://localhost:24280',
-    };
-
-    const context: ToolRegistrationContext = {
-      server: mockServer,
-      systemState,
-      refreshSystemState: async () => {},
-      serverManager: mockServerManager,
-    };
-
-    // ツール登録
-    registerIndexStatusTool(context);
-
-    // ツールハンドラを実行
-    await expect(registeredTool.handler({})).rejects.toThrow('自動起動中です');
-  });
-
-  it('client.getStatus()がエラーの場合、エラーを返す', async () => {
+  it('service.getStatus()がエラーの場合、エラーを返す', async () => {
     const mockClient = {
       getStatus: vi.fn().mockRejectedValue(new Error('Connection error')),
     };
@@ -144,8 +120,7 @@ describe('index_status tool', () => {
       config: {} as any,
       configPath: '/test/.search-docs.json',
       projectRoot: '/test',
-      serverUrl: 'http://localhost:24280',
-      client: mockClient as any,
+      service: mockClient as any,
     };
 
     const context: ToolRegistrationContext = {

--- a/packages/mcp-server/src/tools/add-related-project.ts
+++ b/packages/mcp-server/src/tools/add-related-project.ts
@@ -3,9 +3,7 @@
  * 関連プロジェクトを一時的に追加する
  */
 
-import * as path from 'path';
 import { z } from 'zod';
-import { ConfigLoader } from '@search-docs/types';
 import { SearchDocsClient } from '@search-docs/client';
 import type { ToolRegistrationContext, RegisteredTool } from './types.js';
 
@@ -20,31 +18,19 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
     {
       description:
         '関連プロジェクトを一時的に追加します。追加されたプロジェクトはセッション中のみ有効で、設定ファイルには保存されません。\n' +
-        'dirまたはurlのいずれか一方を指定します。\n' +
-        '- dir: 指定ディレクトリに .search-docs.json が存在する必要があります（.search-docs/config.json も自動検出）\n' +
-        '- url: 起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください（Docker環境ではlocalhostを自動でhost.docker.internalに補正します）',
+        '起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください（Docker環境ではlocalhostを自動でhost.docker.internalに補正します）',
       inputSchema: {
         name: z.string().describe('プロジェクト名（一意の識別子）'),
-        dir: z.string().optional().describe('プロジェクトディレクトリ（相対パスまたは絶対パス）'),
-        url: z.string().optional().describe('起動済みサーバのURL（例: http://localhost:<port>）'),
+        url: z.string().describe('起動済みサーバのURL（例: http://localhost:<port>）'),
         description: z.string().optional().describe('プロジェクトの説明'),
       },
     },
-    async (args: { name: string; dir?: string; url?: string; description?: string }) => {
-      const { name, dir, url, description } = args;
-
-      // dir と url の排他チェック
-      if (!dir && !url) {
-        throw new Error('dir または url のいずれか一方を指定してください。');
-      }
-      if (dir && url) {
-        throw new Error('dir と url は同時に指定できません。どちらか一方のみを指定してください。');
-      }
+    async (args: { name: string; url: string; description?: string }) => {
+      const { name, url, description } = args;
 
       // 名前の重複チェック（設定ファイル + 一時追加分）
       const allRelated = serverManager.getAllRelatedProjects(
-        systemState.config?.relatedProjects,
-        systemState.configPath
+        systemState.config?.relatedProjects
       );
       if (allRelated[name]) {
         throw new Error(
@@ -52,82 +38,33 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
         );
       }
 
-      // URL 指定時の処理
-      if (url) {
-        const { ServerManager } = await import('../server-manager.js');
-        const resolvedUrl = ServerManager.resolveDockerUrl(url);
-        const client = new SearchDocsClient({ baseUrl: resolvedUrl });
-        try {
-          await client.healthCheck();
-        } catch (error) {
-          throw new Error(
-            `指定されたURLのサーバに接続できません: ${url}\n\n` +
-            `エラー: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-
-        // 一時追加（URL形式）
-        serverManager.addTemporaryRelatedProject(name, {
-          url,
-          description,
-        });
-
-        let resultText = `✅ 関連プロジェクト "${name}" を一時的に追加しました。\n\n`;
-        resultText += `  URL: ${url}\n`;
-        if (description) {
-          resultText += `  説明: ${description}\n`;
-        }
-        resultText += `\n⚠️  この追加はセッション中のみ有効です。永続化するには設定ファイルを編集してください。\n\n`;
-        resultText += '次のステップ:\n';
-        resultText += `  - 検索を実行: search(query: "...", project: "${name}")\n`;
-        resultText += `  - 一覧を確認: list_related_projects\n`;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: resultText,
-            },
-          ],
-        };
-      }
-
-      // dir 指定時の処理（既存のまま）
-      if (!dir) {
-        throw new Error('dir が指定されていません。');
-      }
-
-      // ディレクトリを解決（プロジェクトルートからの相対パス）
-      const resolvedDir = path.resolve(systemState.projectRoot, dir);
-
-      // .search-docs.json の存在確認
-      const resolveResult = await ConfigLoader.resolve({
-        cwd: resolvedDir,
-        traverseUp: false,
-        requireConfig: false,
-      });
-
-      if (!resolveResult.config) {
+      // URL接続確認
+      const { ServerManager } = await import('../server-manager.js');
+      const resolvedUrl = ServerManager.resolveDockerUrl(url);
+      const client = new SearchDocsClient({ baseUrl: resolvedUrl });
+      try {
+        await client.healthCheck();
+      } catch (error) {
         throw new Error(
-          `ディレクトリ "${resolvedDir}" に設定ファイルが見つかりません。\n\n` +
-          '関連プロジェクトとして追加するには、対象ディレクトリで init を実行してください。'
+          `指定されたURLのサーバに接続できません: ${url}\n\n` +
+          `エラー: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 
-      // 一時追加（絶対パスで保存）
+      // 一時追加（URL形式）
       serverManager.addTemporaryRelatedProject(name, {
-        dir: resolvedDir,
+        url,
         description,
       });
 
       let resultText = `✅ 関連プロジェクト "${name}" を一時的に追加しました。\n\n`;
-      resultText += `  ディレクトリ: ${resolvedDir}\n`;
+      resultText += `  URL: ${url}\n`;
       if (description) {
         resultText += `  説明: ${description}\n`;
       }
       resultText += `\n⚠️  この追加はセッション中のみ有効です。永続化するには設定ファイルを編集してください。\n\n`;
       resultText += '次のステップ:\n';
-      resultText += `  - サーバを起動: ホスト側で search-docs server start を実行\n`;
+      resultText += `  - 検索を実行: search(query: "...", project: "${name}")\n`;
       resultText += `  - 一覧を確認: list_related_projects\n`;
 
       return {

--- a/packages/mcp-server/src/tools/get-document.ts
+++ b/packages/mcp-server/src/tools/get-document.ts
@@ -39,10 +39,9 @@ export function registerGetDocumentTool(context: ToolRegistrationContext): Regis
       // プロジェクト指定がある場合は関連プロジェクトから取得
       if (project) {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
-        const relatedClient = await context.serverManager.connectRelatedServer(project, allRelated);
+        const relatedClient = await context.serverManager.connectRelatedProject(project, allRelated);
 
         // 関連プロジェクトから文書を取得
         try {
@@ -96,17 +95,16 @@ export function registerGetDocumentTool(context: ToolRegistrationContext): Regis
       // 状態チェック
       if (systemState.state !== 'RUNNING') {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
         const relatedNames = Object.keys(allRelated);
         throw new Error(getStateErrorMessage(systemState.state, '文書の取得', relatedNames));
       }
 
-      const client = systemState.client!;
+      const service = systemState.service!;
 
       try {
-        const response = await client.getDocument({ path: documentPath, sectionId });
+        const response = await service.getDocument({ path: documentPath, sectionId });
 
         if (!response.document && !response.section) {
           throw new Error(`Document or section not found`);

--- a/packages/mcp-server/src/tools/get-outline.ts
+++ b/packages/mcp-server/src/tools/get-outline.ts
@@ -38,10 +38,9 @@ export function registerGetOutlineTool(context: ToolRegistrationContext): Regist
       // プロジェクト指定がある場合は関連プロジェクトから取得
       if (project) {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
-        const relatedClient = await context.serverManager.connectRelatedServer(project, allRelated);
+        const relatedClient = await context.serverManager.connectRelatedProject(project, allRelated);
 
         // 関連プロジェクトからアウトラインを取得
         try {
@@ -74,17 +73,16 @@ export function registerGetOutlineTool(context: ToolRegistrationContext): Regist
       // 状態チェック
       if (systemState.state !== 'RUNNING') {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
         const relatedNames = Object.keys(allRelated);
         throw new Error(getStateErrorMessage(systemState.state, '文書構造の取得', relatedNames));
       }
 
-      const client = systemState.client!;
+      const service = systemState.service!;
 
       try {
-        const response = await client.getOutline({ path: documentPath, sectionId });
+        const response = await service.getOutline({ path: documentPath, sectionId });
 
         let resultText = '';
         if (documentPath) {

--- a/packages/mcp-server/src/tools/index-status.ts
+++ b/packages/mcp-server/src/tools/index-status.ts
@@ -63,10 +63,9 @@ export function registerIndexStatusTool(context: ToolRegistrationContext): Regis
 
       if (project) {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
-        const relatedClient = await context.serverManager.connectRelatedServer(project, allRelated);
+        const relatedClient = await context.serverManager.connectRelatedProject(project, allRelated);
 
         try {
           const response = await relatedClient.getStatus();
@@ -81,17 +80,16 @@ export function registerIndexStatusTool(context: ToolRegistrationContext): Regis
       // 状態チェック
       if (systemState.state !== 'RUNNING') {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
         const relatedNames = Object.keys(allRelated);
         throw new Error(getStateErrorMessage(systemState.state, 'インデックス状態の確認', relatedNames));
       }
 
-      const client = systemState.client!;
+      const service = systemState.service!;
 
       try {
-        const response = await client.getStatus();
+        const response = await service.getStatus();
         let statusText = '📊 インデックス状態\n\n';
         statusText += formatIndexStatus(response);
         return { content: [{ type: 'text' as const, text: statusText }] };

--- a/packages/mcp-server/src/tools/list-related-projects.ts
+++ b/packages/mcp-server/src/tools/list-related-projects.ts
@@ -22,7 +22,7 @@ export function registerListRelatedProjectsTool(context: ToolRegistrationContext
       let resultText = '';
 
       // 関連プロジェクトの存在確認
-      const allRelatedProjects = context.serverManager.getAllRelatedProjects(systemState.config?.relatedProjects, systemState.configPath);
+      const allRelatedProjects = context.serverManager.getAllRelatedProjects(systemState.config?.relatedProjects);
       if (Object.keys(allRelatedProjects).length === 0) {
         resultText += '📋 関連プロジェクト\n\n';
         resultText += '関連プロジェクトは設定されていません。\n\n';
@@ -55,7 +55,7 @@ export function registerListRelatedProjectsTool(context: ToolRegistrationContext
         }
 
         resultText += '\n';
-        resultText += `  ディレクトリ: ${projectConfig.dir}\n`;
+        resultText += `  URL: ${projectConfig.url}\n`;
 
         if (serverInfo) {
           // サーバが起動中

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -60,10 +60,9 @@ export function registerSearchTool(context: ToolRegistrationContext): Registered
       // プロジェクト指定がある場合は関連プロジェクトを検索
       if (project) {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
-        const relatedClient = await context.serverManager.connectRelatedServer(project, allRelated);
+        const relatedClient = await context.serverManager.connectRelatedProject(project, allRelated);
 
         // 関連プロジェクトで検索を実行
         try {
@@ -143,17 +142,16 @@ export function registerSearchTool(context: ToolRegistrationContext): Registered
       // 状態チェック
       if (systemState.state !== 'RUNNING') {
         const allRelated = context.serverManager.getAllRelatedProjects(
-          systemState.config?.relatedProjects,
-          systemState.configPath
+          systemState.config?.relatedProjects
         );
         const relatedNames = Object.keys(allRelated);
         throw new Error(getStateErrorMessage(systemState.state, '文書の検索', relatedNames));
       }
 
-      const client = systemState.client!;
+      const service = systemState.service!;
 
       try {
-        const response = await client.search({
+        const response = await service.search({
           query,
           options: {
             depth,

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -43,11 +43,7 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
                 statusText += ` - ${projectConfig.description}`;
               }
               statusText += '\n';
-              if (projectConfig.url) {
-                statusText += `    URL: ${projectConfig.url}\n`;
-              } else {
-                statusText += `    ディレクトリ: ${projectConfig.dir}\n`;
-              }
+              statusText += `    URL: ${projectConfig.url}\n`;
               if (serverInfo) {
                 try {
                   await serverInfo.client.healthCheck();
@@ -65,20 +61,13 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
           break;
         }
 
-        case 'CONFIGURED_SERVER_DOWN':
-          statusText += '状態: サーバ起動中...\n\n';
-          statusText += `設定ファイル: ${systemState.configPath}\n`;
-          statusText += `プロジェクト: ${systemState.config?.project.name}\n\n`;
-          statusText += 'サーバを自動起動中です。しばらくお待ちください。\n';
-          break;
-
         case 'RUNNING':
           statusText += '状態: 稼働中 ✅\n\n';
           statusText += `設定ファイル: ${systemState.configPath}\n`;
           statusText += `プロジェクト: ${systemState.config?.project.name}\n\n`;
 
           try {
-            const status = await systemState.client!.getStatus();
+            const status = await systemState.service!.getStatus();
 
             if (status.database.connectionState === 'ready') {
               statusText += 'インデックス情報:\n';
@@ -113,7 +102,7 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
 
           // 関連プロジェクト情報
           {
-            const allRelatedProjects = context.serverManager.getAllRelatedProjects(systemState.config?.relatedProjects, systemState.configPath);
+            const allRelatedProjects = context.serverManager.getAllRelatedProjects(systemState.config?.relatedProjects);
             const relatedProjectNames = Object.keys(allRelatedProjects);
             if (relatedProjectNames.length > 0) {
               statusText += '\n関連プロジェクト:\n';

--- a/packages/server/src/server/search-docs-server.ts
+++ b/packages/server/src/server/search-docs-server.ts
@@ -8,6 +8,7 @@ import type {
   OutlineItem,
   GetStatusResponse,
   SearchDocsConfig,
+  SearchDocsService,
 } from '@search-docs/types';
 import { FileStorage } from '@search-docs/storage';
 import { DBEngine } from '@search-docs/db-engine';
@@ -19,7 +20,7 @@ import type { WatcherProcess } from '../watcher/watcher-process.js';
  * 検索・文書取得・アウトライン取得・ステータス取得を担当。
  * ファイル監視・インデックス更新は WatcherProcess が担当。
  */
-export class SearchDocsServer {
+export class SearchDocsServer implements SearchDocsService {
   private startTime: number = 0;
   private watcherProcess?: WatcherProcess;
   private requestStats = {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -3,10 +3,8 @@
  */
 
 export interface RelatedProjectConfig {
-  /** プロジェクトディレクトリ（相対パスまたは絶対パス）。url と排他 */
-  dir?: string;
-  /** リモートサーバURL（例: http://localhost:24280）。dir と排他 */
-  url?: string;
+  /** リモートサーバURL（例: http://localhost:24280） */
+  url: string;
   /** プロジェクトの説明（オプション） */
   description?: string;
 }

--- a/packages/types/src/config/loader.ts
+++ b/packages/types/src/config/loader.ts
@@ -243,37 +243,6 @@ export class ConfigLoader {
     return await this.normalizeProjectRoot(configDir);
   }
 
-  /**
-   * 関連プロジェクトの設定を解決
-   * @param projectName プロジェクト名
-   * @param baseConfigPath ベース設定ファイルのパス
-   * @param relatedProjects 関連プロジェクト設定
-   */
-  static async resolveRelatedProject(
-    projectName: string,
-    baseConfigPath: string,
-    relatedProjects: Record<string, import('../config.js').RelatedProjectConfig>
-  ): Promise<{
-    config: SearchDocsConfig;
-    configPath: string | null;
-    projectRoot: string;
-  } | null> {
-    const relatedProject = relatedProjects[projectName];
-    if (!relatedProject || !relatedProject.dir) {
-      return null;
-    }
-
-    // ベース設定ファイルのディレクトリを基準に相対パスを解決
-    const baseDir = path.dirname(baseConfigPath);
-    const projectDir = path.resolve(baseDir, relatedProject.dir);
-
-    // 関連プロジェクトの設定を読み込む
-    return await this.resolve({
-      cwd: projectDir,
-      traverseUp: false, // 関連プロジェクトでは上位ディレクトリを探索しない
-      requireConfig: false,
-    });
-  }
 
   /**
    * 設定とデフォルト値をマージ

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -50,6 +50,9 @@ export type {
   JsonRpcError,
 } from './api.js';
 
+// Service
+export type { SearchDocsService } from './service.js';
+
 // Storage
 export type { DocumentStorage } from './storage.js';
 

--- a/packages/types/src/service.ts
+++ b/packages/types/src/service.ts
@@ -1,0 +1,16 @@
+import type {
+  SearchRequest,
+  SearchResponse,
+  GetDocumentRequest,
+  GetDocumentResponse,
+  GetOutlineRequest,
+  GetOutlineResponse,
+  GetStatusResponse,
+} from './api.js';
+
+export interface SearchDocsService {
+  search(request: SearchRequest): Promise<SearchResponse>;
+  getDocument(request: GetDocumentRequest): Promise<GetDocumentResponse>;
+  getOutline(request: GetOutlineRequest): Promise<GetOutlineResponse>;
+  getStatus(): Promise<GetStatusResponse>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,15 @@ importers:
       '@search-docs/client':
         specifier: workspace:*
         version: link:../client
+      '@search-docs/db-engine':
+        specifier: workspace:*
+        version: link:../db-engine
+      '@search-docs/server':
+        specifier: workspace:*
+        version: link:../server
+      '@search-docs/storage':
+        specifier: workspace:*
+        version: link:../storage
       '@search-docs/types':
         specifier: workspace:*
         version: link:../types
@@ -230,7 +239,6 @@ packages:
 
   '@coeiro-operator/mcp-debug@1.1.0':
     resolution: {integrity: sha512-foeP/Kl9Q0ByM004c+Zpxv3vXMmYk05S8hYAOTLPqL4EhkBkBV/21KWz8MvFAVgsNqEXpS7KcwN1jJdym+ADeQ==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 description = "🐕️ ローカル文書検索システム - Markdown文書に対するVector検索機能を提供"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "lancedb==0.25.3",
+    "lancedb==0.30.2",
+    "pylance==0.39.0",
     "pyarrow==22.0.0",
     "pandas==2.3.3",
     "numpy==2.3.5",
-    "sentence-transformers==5.1.2",
     "protobuf==6.33.1",
     "sentencepiece==0.2.1",
     "pytest==9.0.1",


### PR DESCRIPTION
## Summary

- MCPサーバがSearchDocsServerインスタンスを直接保持するin-process構成に変更。HTTPデーモンspawnを廃止
- SearchDocsServiceインターフェイスを導入し、in-process（SearchDocsServer）とHTTP（SearchDocsClient）を透過的に扱えるように
- 関連プロジェクトの`dir`指定を廃止し、URL接続のみに限定。サーバ起動は明示的に`search-docs server start`で行う構成に
- db-engineの`get_stats`で内部API(`table._dataset`)を公開API(`table.to_lance()`)に修正

## Test plan

- [ ] `pnpm -r run build` — 全パッケージビルド通過
- [ ] `pnpm -r run lint` — lint通過
- [ ] `pnpm -r run test` — 全テスト通過（db-engineの統計テスト含む）
- [ ] MCPサーバ起動 → search, get_document, get_outline が動作すること
- [ ] 関連プロジェクトをURL指定で追加 → 検索できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)