### PR TITLE
fix: ConfigLoader.resolve()でproject.rootを絶対パスに解決

### DIFF
--- a/.changeset/fix-config-project-root.md
+++ b/.changeset/fix-config-project-root.md
@@ -1,0 +1,5 @@
+---
+"@search-docs/types": patch
+---
+
+fix: ConfigLoader.resolve()でconfig.project.rootを絶対パスに解決するよう修正。Docker環境でWatcherProcessが正しいディレクトリをスキャンしない問題を修正。

--- a/packages/types/src/config/loader.ts
+++ b/packages/types/src/config/loader.ts
@@ -117,6 +117,9 @@ export class ConfigLoader {
       ? await this.load(configPath)
       : this.getDefaultConfig();
 
+    // config.project.root を解決済み絶対パスに置換
+    config.project.root = projectRoot;
+
     return { config, configPath, projectRoot };
   }
 


### PR DESCRIPTION
## Summary
- `ConfigLoader.resolve()`で`config.project.root`を解決済み絶対パスに置換するよう修正
- MCP in-process化後、Docker内（cwd=/app）でWatcherProcessのFileDiscoveryが`/workspace`ではなく`/app`をスキャンし、ドキュメントが1件しかインデックスされないバグを修正

## Root Cause
`ConfigLoader.resolve()`は`projectRoot`を絶対パスとして正しく解決して返していたが、`config.project.root`は設定ファイルの生値（`"."`）のままだった。WatcherProcessが`config.project.root`を参照するため、Docker内ではcwdの`/app`に解決されていた。

## Test plan
- [ ] `pnpm run build:all` — ビルド成功確認
- [ ] Docker MCP起動 → 全ドキュメントがインデックスされること
- [ ] ローカル（npx）MCP起動 → 既存動作に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)