### PR TITLE
chore: changesetにmcp-serverのpatchを追加

### DIFF
--- a/.changeset/fix-config-project-root.md
+++ b/.changeset/fix-config-project-root.md
@@ -1,5 +1,6 @@
 ---
 "@search-docs/types": patch
+"@search-docs/mcp-server": patch
 ---
 
 fix: ConfigLoader.resolve()でconfig.project.rootを絶対パスに解決するよう修正。Docker環境でWatcherProcessが正しいディレクトリをスキャンしない問題を修正。


### PR DESCRIPTION
## Summary
- #90 のchangesetに `@search-docs/mcp-server: patch` を追加
- Docker環境での動作修正はmcp-serverのバージョンにも反映すべきため

🤖 Generated with [Claude Code](https://claude.com/claude-code)