### PR TITLE
fix: indexDocumentでproject.rootを基準に絶対パスを解決

### DIFF
--- a/.changeset/fix-config-project-root.md
+++ b/.changeset/fix-config-project-root.md
@@ -1,5 +1,6 @@
 ---
 "@search-docs/types": patch
+"@search-docs/server": patch
 "@search-docs/mcp-server": patch
 ---
 

--- a/packages/server/src/watcher/watcher-process.ts
+++ b/packages/server/src/watcher/watcher-process.ts
@@ -383,12 +383,13 @@ export class WatcherProcess {
   }
 
   private async indexDocument(filePath: string, force = false): Promise<{ success: boolean; sectionsCreated: number }> {
-    const stat = await fs.stat(filePath);
+    const absolutePath = path.join(this.config.project.root, filePath);
+    const stat = await fs.stat(absolutePath);
     if (stat.size > this.config.files.maxFileSize) {
       return { success: false, sectionsCreated: 0 };
     }
 
-    const content = await fs.readFile(filePath, 'utf-8');
+    const content = await fs.readFile(absolutePath, 'utf-8');
     const hash = createHash('sha256').update(content).digest('hex');
 
     const existingDoc = await this.storage.get(filePath);


### PR DESCRIPTION
## Summary
- `WatcherProcess.indexDocument()`で`FileDiscovery`が返す相対パスを`config.project.root`基準で絶対パスに解決
- #90 の修正と合わせて、Docker in-process環境でのファイルスキャン→インデックスが正常動作する

## Root Cause
`FileDiscovery.findFiles()`は相対パスを返す（ストレージキーとして使うため）。`indexDocument()`がその相対パスをそのまま`fs.stat()`に渡していたが、Docker内ではcwdが`/app`のためENOENTになっていた。

## Test plan
- [ ] Docker MCP起動 → 全ドキュメントがインデックスされること
- [ ] ローカルMCP → 既存動作に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)