### PR TITLE
feat: FileWatcher includeスコープ最適化

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -52,15 +52,24 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: version packages to v${{ steps.version.outputs.version }}"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: version packages to v${{ steps.version.outputs.version }}"
+            git push
+          fi
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr create \
-            --title "Release v${{ steps.version.outputs.version }}" \
-            --body "Release version ${{ steps.version.outputs.version }}" \
-            --base main \
-            --head ${{ github.ref_name }}
+          EXISTING=$(gh pr list --head "${{ github.ref_name }}" --base main --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists"
+          else
+            gh pr create \
+              --title "Release v${{ steps.version.outputs.version }}" \
+              --body "Release version ${{ steps.version.outputs.version }}" \
+              --base main \
+              --head ${{ github.ref_name }}
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ claude mcp add npx -- -y @search-docs/mcp-server
 - ✅ `.search-docs.json` (推奨) または `search-docs.json`
 - ✅ ファイル検索ルール（include/exclude glob）
 - ✅ .gitignoreの尊重
+- ✅ includeスコープ最適化（v1.8.6）: includeパターンから静的プレフィックスを抽出し、FileWatcherの監視範囲を限定
 
 ### 5. LanceDBインデックス戦略
 - ✅ カーディナリティベースのインデックスタイプ選択（BTREE/BITMAP）

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1708,6 +1708,7 @@ const mergedExcludePaths = [
 ## ADR-017: @parcel/watcherによるファイル監視
 
 **日付**: 2026-01-15
+**更新**: 2026-05-07 (v1.8.6 - includeスコープ最適化)
 **状態**: 採用
 **決定者**: 実装チーム
 
@@ -1720,6 +1721,7 @@ Markdownファイルの変更を検出し、自動的にインデックスを更
 - 除外パターン（node_modules、.gitなど）のサポート
 - クロスプラットフォーム対応（Windows/macOS/Linux）
 - メモリ・CPU効率が良い
+- **Docker環境（virtiofs）での inotify 初期化の性能問題への対処** (v1.8.6)
 
 ### 検討した選択肢
 
@@ -1777,11 +1779,14 @@ Facebook製の高性能ファイル監視デーモン。
 
 **依存関係**: `@parcel/watcher@^2.5.1`
 
-**実装ファイル**: `packages/server/src/discovery/file-watcher.ts`
+**実装ファイル**: 
+- `packages/server/src/discovery/file-watcher.ts` - FileWatcher本体
+- `packages/server/src/discovery/include-scope.ts` - プレフィックス抽出ロジック (v1.8.6)
 
 **主な機能**:
 - イベント検出: ファイルの追加・変更・削除
-- ignoreパターンによる除外フィルタリング
+- **複数subscribeルート**: includeパターンから静的プレフィックスを抽出し、各ルートで監視 (v1.8.6)
+- ignoreパターンによる除外フィルタリング（COMMON_IGNORES + files.exclude）
 - includeパターンによる対象絞り込み（minimatch使用）
 - デバウンス機能（デフォルト300ms）
 
@@ -1796,6 +1801,52 @@ Facebook製の高性能ファイル監視デーモン。
 - chokidarより採用実績が少ない（リスクは低い）
 - ネイティブモジュールのため、プラットフォーム依存あり（プリビルドバイナリで軽減）
 
+### includeスコープ最適化 (v1.8.6)
+
+**背景**: Docker環境（virtiofs）での @parcel/watcher の inotify 初期化がCPUを大量消費する問題（Issue #97）。
+
+**問題**: 
+- @parcel/watcher の `subscribe()` は監視ルート以下の**全ディレクトリを再帰走査**し、各ディレクトリに `inotify_add_watch()` を設定
+- virtiofs経由のFS操作はホストとのIPC往復があり、ディレクトリ数に比例して遅くなる
+- 従来は `project.root` 全体を subscribe し、イベント受信後に `shouldProcessFile()` でフィルタしていた
+
+**解決策**: 2層の協調によるスコープ制限
+
+1. **Layer 1 - subscribeルート（粗いスコープ制限）**
+   - `files.include` パターンから静的ディレクトリプレフィックスを抽出
+   - 例: `"docs/**/*.md"` → `"docs"`、`"**/*.md"` → `""` (プロジェクトルート)
+   - プレフィックスごとに `watcher.subscribe()` を実行
+   - **スコープ外のディレクトリは最初から inotify 走査の対象にならない**
+
+2. **Layer 2 - shouldProcessFile（精密なフィルタ）**
+   - `files.include` パターンの詳細マッチ + `.md` 拡張子チェック
+   - 例: `docs/**` は `docs/sub/file.md` を通すが、`docs/*` は弾く
+
+**実装**:
+```typescript
+// subscription (単一) → subscriptions (配列) に変更
+private subscriptions: watcher.AsyncSubscription[] = [];
+
+async start(): Promise<void> {
+  const { subscribeRoots, ignorePatterns } = buildWatchTargets(
+    this.rootDir,
+    this.filesConfig
+  );
+
+  for (const subscribeRoot of subscribeRoots) {
+    const sub = await watcher.subscribe(subscribeRoot, callback, opts);
+    this.subscriptions.push(sub);
+  }
+}
+```
+
+**効果**:
+- Docker環境（virtiofs）での inotify 初期化時のCPU消費を大幅削減
+- 大規模モノレポでの監視スコープ最適化
+- `files.include` が実質的な**ディレクトリスコープ宣言**として機能
+
+**関連**: Issue #97, PR #98, commit e659d40
+
 ### 今後の検討事項
 
 1. **Watchmanの推奨**
@@ -1809,7 +1860,10 @@ Facebook製の高性能ファイル監視デーモン。
 ### 参考資料
 
 - 実装ファイル: `packages/server/src/discovery/file-watcher.ts`
+- プレフィックス抽出: `packages/server/src/discovery/include-scope.ts` (v1.8.6)
 - Nuxt.jsでの採用: `experimental: { watcher: 'parcel' }`
+- Issue #97: Docker環境でFileWatcherのinotify初期化がCPUを大量消費
+- task44: `prompts/tasks/task44.filewatcher-include-scope-optimization.v1.md`
 
 ---
 

--- a/docs/file-watcher-design.md
+++ b/docs/file-watcher-design.md
@@ -22,9 +22,9 @@ Markdownファイルの変更を監視し、自動的にインデックスを更
 
 ```
 FileWatcher (@parcel/watcher)
-  ├─ subscription (ネイティブC++監視)
-  ├─ ignoreパターン (除外フィルタ)
-  ├─ shouldProcessFile (includeパターンチェック)
+  ├─ subscriptions (複数ルート監視、includeスコープ最適化)
+  ├─ ignoreパターン (COMMON_IGNORES + files.exclude)
+  ├─ shouldProcessFile (includeパターン詳細マッチ)
   └─ デバウンス (300ms)
        ↓
   FileChangeEvent発火
@@ -34,39 +34,85 @@ FileWatcher (@parcel/watcher)
        └─ unlink → deleteDocument()
 ```
 
+### include スコープ最適化 (v1.8.6以降)
+
+**2層の協調によるスコープ制限**:
+
+1. **Layer 1 - subscribeルート（粗いスコープ制限）**
+   - `files.include` パターンから静的ディレクトリプレフィックスを抽出
+   - 例: `docs/**/*.md` → `docs/`、`**/*.md` → プロジェクトルート
+   - プレフィックスごとに `watcher.subscribe()` を実行
+   - **スコープ外のディレクトリは最初から inotify 走査の対象にならない**
+
+2. **Layer 2 - shouldProcessFile（精密なフィルタ）**
+   - `files.include` パターンの詳細マッチ + `.md` 拡張子チェック
+   - 例: `docs/**` は `docs/sub/file.md` を通すが、`docs/*` は弾く
+
+**効果**:
+- Docker環境（virtiofs）での inotify 初期化時のCPU消費を大幅削減
+- 大規模モノレポでの監視スコープ最適化
+- `files.include` が実質的な**ディレクトリスコープ宣言**として機能
+
+詳細: [Issue #97](https://github.com/otolab/search-docs/issues/97), [PR #98](https://github.com/otolab/search-docs/pull/98)
+
 ### 実装ファイル
 
-**場所**: `packages/server/src/discovery/file-watcher.ts`
+**場所**: 
+- `packages/server/src/discovery/file-watcher.ts` - FileWatcher本体
+- `packages/server/src/discovery/include-scope.ts` - プレフィックス抽出ロジック
 
 **主要クラス**: `FileWatcher`
 
 ```typescript
 export class FileWatcher extends EventEmitter {
-  private subscription: watcher.AsyncSubscription | null = null;
+  private subscriptions: watcher.AsyncSubscription[] = [];
   private debounceTimers = new Map<string, NodeJS.Timeout>();
 
   async start(): Promise<void> {
-    const ignorePatterns = this.buildIgnorePatterns();
-
-    this.subscription = await watcher.subscribe(
+    const { subscribeRoots, ignorePatterns } = buildWatchTargets(
       this.rootDir,
-      (err, events) => {
-        for (const event of events) {
-          const eventType = this.convertEventType(event.type);
-          if (this.shouldProcessFile(event.path)) {
-            this.handleFileEvent(eventType, event.path);
-          }
-        }
-      },
-      { ignore: ignorePatterns }
+      this.filesConfig
     );
+
+    for (const subscribeRoot of subscribeRoots) {
+      const sub = await watcher.subscribe(
+        subscribeRoot,
+        (err, events) => {
+          for (const event of events) {
+            const eventType = this.convertEventType(event.type);
+            if (this.shouldProcessFile(event.path)) {
+              this.handleFileEvent(eventType, event.path);
+            }
+          }
+        },
+        { ignore: ignorePatterns }
+      );
+      this.subscriptions.push(sub);
+    }
   }
 
   async stop(): Promise<void> {
-    await this.subscription?.unsubscribe();
+    for (const sub of this.subscriptions) {
+      await sub.unsubscribe();
+    }
+    this.subscriptions = [];
   }
 }
 ```
+
+**プレフィックス抽出ロジック**:
+
+`buildWatchTargets()` は以下の処理を行います:
+
+1. `extractDirectoryPrefixes()`: includeパターンから静的プレフィックスを抽出
+   - 例: `"docs/**/*.md"` → `"docs"`
+   - 例: `"**/*.md"` → `""` (空 = プロジェクトルート)
+   - 重複排除・包含関係の解決（親が含まれていれば子は不要）
+
+2. `resolveSubscribeRoots()`: プレフィックスを絶対パスに解決
+   - 例: `"docs"` → `/path/to/project/docs`
+
+3. ignoreパターンの構築: `COMMON_IGNORES + files.exclude`
 
 ### 主な機能
 
@@ -77,18 +123,32 @@ export class FileWatcher extends EventEmitter {
 
 2. **除外パターン**
    ```typescript
-   const commonIgnores = [
+   // packages/server/src/discovery/include-scope.ts
+   export const COMMON_IGNORES = [
      '**/node_modules/**',
      '**/.git/**',
+     '**/.pnpm-store/**',
+     '**/.yarn/**',
      '**/.venv/**',
+     '**/.uv/**',
      '**/dist/**',
      '**/build/**',
+     '**/.next/**',
+     '**/.turbo/**',
+     '**/coverage/**',
+     '**/.cache/**',
      '**/.search-docs/**',
+     '**/__pycache__/**',
+     '**/.mypy_cache/**',
+     '**/.pytest_cache/**',
    ];
    ```
 
+   **注**: COMMON_IGNORES はパフォーマンス最適化のために定義されており、@parcel/watcherのinotify初期走査時にサブツリー全体をスキップします。
+
 3. **includeパターンのフィルタリング**
-   - `filesConfig.include`に基づいて監視対象を絞り込み
+   - `files.include`パターンから静的プレフィックスを抽出し、subscribeルートを限定（Layer 1）
+   - `shouldProcessFile()`で詳細マッチ（Layer 2）
    - `minimatch`による柔軟なパターンマッチング
 
 4. **デバウンス機能**

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,9 +100,10 @@ search-docsを使う前に、基本的な構成要素を理解しましょう。
 - 複数プロジェクトを同時に使用可能
 
 **ファイル監視**:
-- chokidarによるリアルタイム監視
-- debounce処理（デフォルト1秒）で連続変更を効率的に処理
+- @parcel/watcherによるリアルタイム監視（ネイティブC++実装）
+- debounce処理（デフォルト300ms）で連続変更を効率的に処理
 - 変更検知後、該当Documentを自動的にDirtyにマーク
+- **includeスコープ最適化**: includeパターンから静的プレフィックスを抽出し、監視範囲を限定（v1.8.6）
 
 **バックグラウンド更新**:
 - IndexWorkerが定期的に（デフォルト5秒間隔）Dirtyセクションを処理
@@ -345,6 +346,27 @@ search-docs server stop
 1. `exclude`パターン（最優先）
 2. `.gitignore`（`ignoreGitignore: true`の場合）
 3. `include`パターン
+
+**includeパターンによるディレクトリスコープ最適化** (v1.8.6):
+
+`files.include` は実質的な**ディレクトリスコープ宣言**として機能します。FileWatcherは includeパターンから静的ディレクトリプレフィックスを抽出し、監視範囲を限定します。
+
+- `["docs/**/*.md"]` → `docs/` のみ監視
+- `["**/*.md"]` → プロジェクト全体を監視（デフォルト）
+- `["docs/**", "blog/**"]` → `docs/` と `blog/` を監視
+
+**大規模プロジェクト・モノレポでの推奨設定**:
+
+```json
+{
+  "files": {
+    "include": ["docs/**"],
+    "exclude": ["**/node_modules/**", "**/.git/**", "**/dist/**"]
+  }
+}
+```
+
+より具体的な `include` パターンを設定することで、FileWatcherの監視スコープが狭まり、パフォーマンスが向上します。特にDocker環境（virtiofs）で効果的です。
 
 #### indexing
 

--- a/packages/server/src/discovery/__tests__/include-scope.test.ts
+++ b/packages/server/src/discovery/__tests__/include-scope.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { extractDirectoryPrefixes, resolveSubscribeRoots } from '../include-scope.js';
+
+describe('extractDirectoryPrefixes', () => {
+  it('globメタ文字の手前までを抽出する', () => {
+    expect(extractDirectoryPrefixes(['docs/**/*.md'])).toEqual(['docs']);
+  });
+
+  it('先頭が ** の場合はルート（空文字列）', () => {
+    expect(extractDirectoryPrefixes(['**/*.md'])).toEqual(['']);
+  });
+
+  it('深いパスのプレフィックスを抽出する', () => {
+    expect(extractDirectoryPrefixes(['content/blog/**'])).toEqual([
+      'content/blog',
+    ]);
+  });
+
+  it('複数の独立したプレフィックスを返す', () => {
+    const result = extractDirectoryPrefixes(['docs/**', 'blog/**']);
+    expect(result).toEqual(expect.arrayContaining(['docs', 'blog']));
+    expect(result).toHaveLength(2);
+  });
+
+  it('包含関係を解決する（親に集約）', () => {
+    expect(
+      extractDirectoryPrefixes(['systems/**', 'systems/docs/**'])
+    ).toEqual(['systems']);
+  });
+
+  it('ルートパターンが含まれると全て集約される', () => {
+    expect(
+      extractDirectoryPrefixes(['docs/**', '**/*.md', 'blog/**'])
+    ).toEqual(['']);
+  });
+
+  it('ファイル名パターンはディレクトリから除外される', () => {
+    expect(extractDirectoryPrefixes(['README.md'])).toEqual(['']);
+  });
+
+  it('複雑なモノレポパターン', () => {
+    const result = extractDirectoryPrefixes([
+      'systems/**/packages/**/docs/**',
+      'systems/*',
+      'systems/docs/**',
+    ]);
+    expect(result).toEqual(['systems']);
+  });
+
+  it('重複パターンは排除される', () => {
+    expect(
+      extractDirectoryPrefixes(['docs/**/*.md', 'docs/**'])
+    ).toEqual(['docs']);
+  });
+
+  it('空配列はルートを返す', () => {
+    expect(extractDirectoryPrefixes([])).toEqual(['']);
+  });
+
+  it('packages配下の複数パス', () => {
+    const result = extractDirectoryPrefixes([
+      'packages/*/docs/**',
+      'docs/**',
+    ]);
+    expect(result).toEqual(expect.arrayContaining(['packages', 'docs']));
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('resolveSubscribeRoots', () => {
+  const rootDir = '/project';
+
+  it('空プレフィックスはrootDir自体を返す', () => {
+    expect(resolveSubscribeRoots(rootDir, [''])).toEqual(['/project']);
+  });
+
+  it('プレフィックスをrootDirに結合する', () => {
+    expect(resolveSubscribeRoots(rootDir, ['docs'])).toEqual([
+      path.join('/project', 'docs'),
+    ]);
+  });
+
+  it('複数プレフィックスを解決する', () => {
+    expect(resolveSubscribeRoots(rootDir, ['docs', 'blog'])).toEqual([
+      path.join('/project', 'docs'),
+      path.join('/project', 'blog'),
+    ]);
+  });
+});

--- a/packages/server/src/discovery/__tests__/include-scope.test.ts
+++ b/packages/server/src/discovery/__tests__/include-scope.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import * as path from 'path';
-import { extractDirectoryPrefixes, resolveSubscribeRoots } from '../include-scope.js';
+import { minimatch } from 'minimatch';
+import {
+  extractDirectoryPrefixes,
+  resolveSubscribeRoots,
+  buildWatchTargets,
+  COMMON_IGNORES,
+} from '../include-scope.js';
 
 describe('extractDirectoryPrefixes', () => {
   it('globメタ文字の手前までを抽出する', () => {
@@ -86,5 +92,205 @@ describe('resolveSubscribeRoots', () => {
       path.join('/project', 'docs'),
       path.join('/project', 'blog'),
     ]);
+  });
+});
+
+/*
+ * buildWatchTargets — 仕様テスト
+ *
+ * FileWatcherの監視スコープは2層の協調で制御される:
+ *
+ *   Layer 1: subscribeルート（buildWatchTargetsが決定）
+ *     includeパターンの静的プレフィックスで@parcel/watcherのsubscribe先を限定する。
+ *     docs/** も docs/* も同じ "docs/" をsubscribeする。
+ *     スコープ外のディレクトリは最初からinotify走査の対象にならない。
+ *
+ *   Layer 2: shouldProcessFile（FileWatcherクラスが実行）
+ *     includeパターンの詳細マッチ + .md拡張子チェック。
+ *     docs/** は docs/sub/file.md を通すが、docs/* は弾く。
+ *
+ *   ignorePatterns:
+ *     COMMON_IGNORES + files.exclude を @parcel/watcher に渡す。
+ *     subscribeルート内部の不要サブツリーを枝刈りする。
+ */
+describe('buildWatchTargets', () => {
+  const rootDir = '/project';
+
+  const makeConfig = (
+    include: string[],
+    exclude: string[] = []
+  ) => ({
+    include,
+    exclude,
+    ignoreGitignore: false,
+    maxFileSize: 10 * 1024 * 1024,
+  });
+
+  // --- A. subscribeルートの決定 ---
+
+  describe('subscribeルートの決定', () => {
+    it('特定ディレクトリパターン → そのディレクトリをsubscribe', () => {
+      const { subscribeRoots } = buildWatchTargets(
+        rootDir,
+        makeConfig(['docs/**/*.md'])
+      );
+      expect(subscribeRoots).toEqual([path.join(rootDir, 'docs')]);
+    });
+
+    it('独立した複数パターン → 複数のsubscribe', () => {
+      const { subscribeRoots } = buildWatchTargets(
+        rootDir,
+        makeConfig(['docs/**', 'blog/**'])
+      );
+      expect(subscribeRoots).toHaveLength(2);
+      expect(subscribeRoots).toEqual(
+        expect.arrayContaining([
+          path.join(rootDir, 'docs'),
+          path.join(rootDir, 'blog'),
+        ])
+      );
+    });
+
+    it('ルートパターン(**/*.md) → プロジェクトルート全体をsubscribe', () => {
+      const { subscribeRoots } = buildWatchTargets(
+        rootDir,
+        makeConfig(['**/*.md'])
+      );
+      expect(subscribeRoots).toEqual([rootDir]);
+    });
+
+    it('包含関係のあるパターン → 親プレフィックスに集約', () => {
+      const { subscribeRoots } = buildWatchTargets(
+        rootDir,
+        makeConfig([
+          'systems/**/packages/**/docs/**',
+          'systems/*',
+          'systems/docs/**',
+        ])
+      );
+      expect(subscribeRoots).toEqual([path.join(rootDir, 'systems')]);
+    });
+  });
+
+  // --- B. docs/** と docs/* の2層協調 ---
+
+  describe('docs/** と docs/* — subscribeルートは同一、shouldProcessFileで差が出る', () => {
+    // subscribeルートは「パターンが要求する最大範囲」を監視する。
+    // docs/** も docs/* もglobメタ文字の手前は "docs" なので、
+    // @parcel/watcher には docs/ ディレクトリ全体をsubscribeする。
+    // 深い階層のファイルを通すか弾くかは shouldProcessFile の責任。
+
+    it('docs/** と docs/* は同じsubscribeルートを生成する', () => {
+      const recursive = buildWatchTargets(rootDir, makeConfig(['docs/**']));
+      const shallow = buildWatchTargets(rootDir, makeConfig(['docs/*']));
+
+      expect(recursive.subscribeRoots).toEqual(shallow.subscribeRoots);
+      expect(recursive.subscribeRoots).toEqual([
+        path.join(rootDir, 'docs'),
+      ]);
+    });
+
+    // shouldProcessFile はFileWatcherのprivateメソッドだが、
+    // 核心ロジックはminimatchなので、ここで同等のチェックを直接テストする。
+
+    it('docs/** はサブディレクトリのファイルにマッチする', () => {
+      expect(minimatch('docs/sub/file.md', 'docs/**')).toBe(true);
+      expect(minimatch('docs/a/b/c/file.md', 'docs/**')).toBe(true);
+    });
+
+    it('docs/* はサブディレクトリのファイルにマッチしない', () => {
+      expect(minimatch('docs/sub/file.md', 'docs/*')).toBe(false);
+      expect(minimatch('docs/file.md', 'docs/*')).toBe(true);
+    });
+
+    it('docs/**/*.md は再帰的に.mdにマッチする', () => {
+      expect(minimatch('docs/guide.md', 'docs/**/*.md')).toBe(true);
+      expect(minimatch('docs/sub/guide.md', 'docs/**/*.md')).toBe(true);
+      expect(minimatch('docs/sub/guide.txt', 'docs/**/*.md')).toBe(false);
+    });
+  });
+
+  // --- C. ignoreパターンの構成 ---
+
+  describe('ignoreパターンの構成', () => {
+    it('exclude空 → COMMON_IGNORESのみ', () => {
+      const { ignorePatterns } = buildWatchTargets(
+        rootDir,
+        makeConfig(['**/*.md'], [])
+      );
+      expect(ignorePatterns).toEqual([...COMMON_IGNORES]);
+    });
+
+    it('excludeパターン → COMMON_IGNORES + ユーザー設定', () => {
+      const { ignorePatterns } = buildWatchTargets(
+        rootDir,
+        makeConfig(['**/*.md'], ['**/drafts/**'])
+      );
+      expect(ignorePatterns).toContain('**/drafts/**');
+      for (const common of COMMON_IGNORES) {
+        expect(ignorePatterns).toContain(common);
+      }
+    });
+
+    it('COMMON_IGNORESにはパフォーマンス上重要なパターンが含まれる', () => {
+      // inotify走査で最も大きなサブツリーを枝刈りするパターン
+      expect(COMMON_IGNORES).toContain('**/node_modules/**');
+      expect(COMMON_IGNORES).toContain('**/.git/**');
+      expect(COMMON_IGNORES).toContain('**/dist/**');
+      expect(COMMON_IGNORES).toContain('**/.search-docs/**');
+    });
+  });
+
+  // --- D. 結合検証 ---
+
+  describe('subscribeルート + ignoreパターンの結合', () => {
+    it('includeでスコープ限定 + excludeで内部を枝刈り', () => {
+      const { subscribeRoots, ignorePatterns } = buildWatchTargets(
+        rootDir,
+        makeConfig(['docs/**'], ['**/drafts/**'])
+      );
+
+      // subscribeルートはdocs/のみ
+      expect(subscribeRoots).toEqual([path.join(rootDir, 'docs')]);
+
+      // ignoreにdraftsとcommonIgnoresが含まれる
+      expect(ignorePatterns).toContain('**/drafts/**');
+      expect(ignorePatterns).toContain('**/node_modules/**');
+    });
+
+    it('モノレポ設定: 複数パターン + 複数exclude', () => {
+      const { subscribeRoots, ignorePatterns } = buildWatchTargets(
+        rootDir,
+        makeConfig(
+          ['docs/**', 'packages/*/docs/**'],
+          ['**/node_modules/**', '**/dist/**', '**/src/**']
+        )
+      );
+
+      expect(subscribeRoots).toHaveLength(2);
+      expect(subscribeRoots).toEqual(
+        expect.arrayContaining([
+          path.join(rootDir, 'docs'),
+          path.join(rootDir, 'packages'),
+        ])
+      );
+
+      expect(ignorePatterns).toContain('**/src/**');
+      expect(ignorePatterns).toContain('**/node_modules/**');
+    });
+
+    it('デフォルト設定(include: ["**/*.md"]) → ルート全体subscribe', () => {
+      const { subscribeRoots, ignorePatterns } = buildWatchTargets(
+        rootDir,
+        makeConfig(
+          ['**/*.md'],
+          ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/build/**']
+        )
+      );
+
+      expect(subscribeRoots).toEqual([rootDir]);
+      expect(ignorePatterns).toContain('**/node_modules/**');
+      expect(ignorePatterns).toContain('**/.git/**');
+    });
   });
 });

--- a/packages/server/src/discovery/file-watcher.ts
+++ b/packages/server/src/discovery/file-watcher.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
 import type { FilesConfig, WatcherConfig } from '@search-docs/types';
+import { extractDirectoryPrefixes, resolveSubscribeRoots } from './include-scope.js';
 
 export interface FileWatcherOptions {
   /** プロジェクトルート */
@@ -25,7 +26,7 @@ export interface FileChangeEvent {
  * @parcel/watcherを使用してMarkdownファイルの変更を監視
  */
 export class FileWatcher extends EventEmitter {
-  private subscription: watcher.AsyncSubscription | null = null;
+  private subscriptions: watcher.AsyncSubscription[] = [];
   private debounceTimers = new Map<string, NodeJS.Timeout>();
   private rootDir: string;
   private filesConfig: FilesConfig;
@@ -42,37 +43,45 @@ export class FileWatcher extends EventEmitter {
    * 監視を開始
    */
   isRunning(): boolean {
-    return this.subscription !== null;
+    return this.subscriptions.length > 0;
   }
 
   async start(): Promise<void> {
-    // ignoreパターンの構築
     const ignorePatterns = this.buildIgnorePatterns();
 
-    this.subscription = await watcher.subscribe(
-      this.rootDir,
-      (err, events) => {
-        if (err) {
-          this.emit('error', err);
-          return;
-        }
+    const prefixes = extractDirectoryPrefixes(this.filesConfig.include);
+    const subscribeRoots = resolveSubscribeRoots(this.rootDir, prefixes);
 
-        for (const event of events) {
-          // イベントタイプの変換
-          const eventType = this.convertEventType(event.type);
-
-          // 追加のフィルタリング（.md拡張子チェック）
-          if (!this.shouldProcessFile(event.path)) {
-            continue;
-          }
-
-          this.handleFileEvent(eventType, event.path);
-        }
-      },
-      {
-        ignore: ignorePatterns,
+    const callback: watcher.SubscribeCallback = (err, events) => {
+      if (err) {
+        this.emit('error', err);
+        return;
       }
-    );
+
+      for (const event of events) {
+        const eventType = this.convertEventType(event.type);
+
+        if (!this.shouldProcessFile(event.path)) {
+          continue;
+        }
+
+        this.handleFileEvent(eventType, event.path);
+      }
+    };
+
+    const opts: watcher.Options = { ignore: ignorePatterns };
+
+    for (const subscribeRoot of subscribeRoots) {
+      try {
+        if (!fs.existsSync(subscribeRoot)) {
+          continue;
+        }
+        const sub = await watcher.subscribe(subscribeRoot, callback, opts);
+        this.subscriptions.push(sub);
+      } catch (err) {
+        this.emit('error', err);
+      }
+    }
 
     this.emit('ready');
   }
@@ -87,11 +96,11 @@ export class FileWatcher extends EventEmitter {
     }
     this.debounceTimers.clear();
 
-    // subscriptionを停止
-    if (this.subscription) {
-      await this.subscription.unsubscribe();
-      this.subscription = null;
+    // 全subscriptionを停止
+    for (const sub of this.subscriptions) {
+      await sub.unsubscribe();
     }
+    this.subscriptions = [];
   }
 
   /**
@@ -101,17 +110,25 @@ export class FileWatcher extends EventEmitter {
     const patterns: string[] = [];
 
     // 一般的な除外ディレクトリ（最優先）
+    // inotifyバックエンド(Linux)ではsubscribe時に全ディレクトリを走査して
+    // watchを設定するため、不要なディレクトリの除外がパフォーマンスに直結する
     const commonIgnores = [
       '**/node_modules/**',
       '**/.git/**',
+      '**/.pnpm-store/**',
+      '**/.yarn/**',
       '**/.venv/**',
+      '**/.uv/**',
       '**/dist/**',
       '**/build/**',
       '**/.next/**',
       '**/.turbo/**',
       '**/coverage/**',
       '**/.cache/**',
-      '**/.search-docs/**',  // search-docs自身のディレクトリ
+      '**/.search-docs/**',
+      '**/__pycache__/**',
+      '**/.mypy_cache/**',
+      '**/.pytest_cache/**',
     ];
     patterns.push(...commonIgnores);
 

--- a/packages/server/src/discovery/file-watcher.ts
+++ b/packages/server/src/discovery/file-watcher.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
 import type { FilesConfig, WatcherConfig } from '@search-docs/types';
-import { extractDirectoryPrefixes, resolveSubscribeRoots } from './include-scope.js';
+import { buildWatchTargets } from './include-scope.js';
 
 export interface FileWatcherOptions {
   /** プロジェクトルート */
@@ -47,10 +47,7 @@ export class FileWatcher extends EventEmitter {
   }
 
   async start(): Promise<void> {
-    const ignorePatterns = this.buildIgnorePatterns();
-
-    const prefixes = extractDirectoryPrefixes(this.filesConfig.include);
-    const subscribeRoots = resolveSubscribeRoots(this.rootDir, prefixes);
+    const { subscribeRoots, ignorePatterns } = buildWatchTargets(this.rootDir, this.filesConfig);
 
     const callback: watcher.SubscribeCallback = (err, events) => {
       if (err) {
@@ -101,44 +98,6 @@ export class FileWatcher extends EventEmitter {
       await sub.unsubscribe();
     }
     this.subscriptions = [];
-  }
-
-  /**
-   * ignoreパターンを構築
-   */
-  private buildIgnorePatterns(): string[] {
-    const patterns: string[] = [];
-
-    // 一般的な除外ディレクトリ（最優先）
-    // inotifyバックエンド(Linux)ではsubscribe時に全ディレクトリを走査して
-    // watchを設定するため、不要なディレクトリの除外がパフォーマンスに直結する
-    const commonIgnores = [
-      '**/node_modules/**',
-      '**/.git/**',
-      '**/.pnpm-store/**',
-      '**/.yarn/**',
-      '**/.venv/**',
-      '**/.uv/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/.next/**',
-      '**/.turbo/**',
-      '**/coverage/**',
-      '**/.cache/**',
-      '**/.search-docs/**',
-      '**/__pycache__/**',
-      '**/.mypy_cache/**',
-      '**/.pytest_cache/**',
-    ];
-    patterns.push(...commonIgnores);
-
-    // ユーザー設定のexcludeパターン
-    patterns.push(...this.filesConfig.exclude);
-
-    // .md以外のファイルフィルタはshouldProcessFile()で行う
-    // extglobパターン（!(...)）はpicomatch→C++ regexで極端に遅延するため使用しない
-
-    return patterns;
   }
 
   /**

--- a/packages/server/src/discovery/file-watcher.ts
+++ b/packages/server/src/discovery/file-watcher.ts
@@ -70,7 +70,9 @@ export class FileWatcher extends EventEmitter {
 
     for (const subscribeRoot of subscribeRoots) {
       try {
-        if (!fs.existsSync(subscribeRoot)) {
+        try {
+          if (!fs.statSync(subscribeRoot).isDirectory()) continue;
+        } catch {
           continue;
         }
         const sub = await watcher.subscribe(subscribeRoot, callback, opts);
@@ -93,9 +95,13 @@ export class FileWatcher extends EventEmitter {
     }
     this.debounceTimers.clear();
 
-    // 全subscriptionを停止
+    // 全subscriptionを停止（途中の例外でリークしないよう個別にtry-catch）
     for (const sub of this.subscriptions) {
-      await sub.unsubscribe();
+      try {
+        await sub.unsubscribe();
+      } catch (err) {
+        this.emit('error', err);
+      }
     }
     this.subscriptions = [];
   }

--- a/packages/server/src/discovery/include-scope.ts
+++ b/packages/server/src/discovery/include-scope.ts
@@ -1,6 +1,69 @@
 import * as path from 'path';
+import type { FilesConfig } from '@search-docs/types';
 
 const GLOB_METACHARACTERS = new Set(['*', '?', '{', '[']);
+
+/**
+ * @parcel/watcher の inotify初期走査で常に除外すべきディレクトリ群。
+ * inotifyバックエンド(Linux)では subscribe() 時に全ディレクトリを再帰走査して
+ * watchを設定するため、不要なディレクトリの除外がパフォーマンスに直結する。
+ */
+export const COMMON_IGNORES = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/.pnpm-store/**',
+  '**/.yarn/**',
+  '**/.venv/**',
+  '**/.uv/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/coverage/**',
+  '**/.cache/**',
+  '**/.search-docs/**',
+  '**/__pycache__/**',
+  '**/.mypy_cache/**',
+  '**/.pytest_cache/**',
+] as const;
+
+export interface WatchTargets {
+  subscribeRoots: string[];
+  ignorePatterns: string[];
+}
+
+/**
+ * FilesConfigからFileWatcherのsubscribeルートとignoreパターンを決定する。
+ *
+ * 2層の協調で監視スコープを制御する:
+ *
+ * Layer 1 — subscribeルート（粗いスコープ制限）:
+ *   includeパターンの静的プレフィックスでsubscribe先を限定する。
+ *   docs/** も docs/* も同じ "docs/" をsubscribeする。
+ *   スコープ外のディレクトリは最初から走査されない。
+ *
+ * Layer 2 — shouldProcessFile（精密なフィルタ、この関数の範囲外）:
+ *   includeパターンの詳細マッチ + .md拡張子チェック。
+ *   docs/** は docs/sub/file.md を通すが、docs/* は弾く。
+ *
+ * ignorePatterns:
+ *   COMMON_IGNORES（パフォーマンス最適化）+ files.exclude（ユーザー設定）。
+ *   @parcel/watcher に渡され、subscribe先内部の不要サブツリーを枝刈りする。
+ */
+export function buildWatchTargets(
+  rootDir: string,
+  filesConfig: FilesConfig
+): WatchTargets {
+  const prefixes = extractDirectoryPrefixes(filesConfig.include);
+  const subscribeRoots = resolveSubscribeRoots(rootDir, prefixes);
+
+  const ignorePatterns: string[] = [
+    ...COMMON_IGNORES,
+    ...filesConfig.exclude,
+  ];
+
+  return { subscribeRoots, ignorePatterns };
+}
 
 /**
  * includeパターンからglobメタ文字の手前までの静的ディレクトリプレフィックスを抽出する。

--- a/packages/server/src/discovery/include-scope.ts
+++ b/packages/server/src/discovery/include-scope.ts
@@ -1,0 +1,94 @@
+import * as path from 'path';
+
+const GLOB_METACHARACTERS = new Set(['*', '?', '{', '[']);
+
+/**
+ * includeパターンからglobメタ文字の手前までの静的ディレクトリプレフィックスを抽出する。
+ *
+ * @example
+ *   "docs/**\/*.md"                    → "docs"
+ *   "systems/**\/packages/**\/docs/**" → "systems"
+ *   "**\/*.md"                         → ""
+ *   "README.md"                        → ""
+ *   "content/blog/**"                  → "content/blog"
+ */
+function extractPrefix(pattern: string): string {
+  const segments = pattern.split('/');
+  const staticSegments: string[] = [];
+
+  for (const segment of segments) {
+    if ([...segment].some((ch) => GLOB_METACHARACTERS.has(ch))) {
+      break;
+    }
+    staticSegments.push(segment);
+  }
+
+  // ファイル名(拡張子付き)がある場合は除外してディレクトリのみにする
+  if (staticSegments.length > 0) {
+    const last = staticSegments[staticSegments.length - 1];
+    if (last.includes('.')) {
+      staticSegments.pop();
+    }
+  }
+
+  return staticSegments.join('/');
+}
+
+/**
+ * includeパターン配列からsubscribeすべきディレクトリプレフィックスを抽出する。
+ *
+ * 1. 各パターンから静的プレフィックスを抽出
+ * 2. 重複排除
+ * 3. 包含関係を解決（親が含まれていれば子は不要）
+ *
+ * 空文字列 "" はプロジェクトルート全体を意味する。
+ * 結果に "" が含まれる場合、他の全てのプレフィックスは不要。
+ */
+export function extractDirectoryPrefixes(patterns: string[]): string[] {
+  if (patterns.length === 0) {
+    return [''];
+  }
+
+  const prefixes = patterns.map(extractPrefix);
+
+  // 正規化: 末尾スラッシュ除去、パス区切り統一
+  const normalized = prefixes.map((p) => p.replace(/\/+$/, ''));
+
+  // 重複排除
+  const unique = [...new Set(normalized)];
+
+  // 空文字列（ルート）が含まれていれば、他は全て包含される
+  if (unique.includes('')) {
+    return [''];
+  }
+
+  // ソート（短い方が先 → 親が先に来る）
+  unique.sort((a, b) => a.length - b.length);
+
+  // 包含関係の解決: 親プレフィックスに包含される子を除去
+  const result: string[] = [];
+  for (const prefix of unique) {
+    const isContained = result.some(
+      (existing) =>
+        prefix === existing || prefix.startsWith(existing + '/')
+    );
+    if (!isContained) {
+      result.push(prefix);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * プレフィックス配列をrootDir基準の絶対パスに解決する。
+ * 空文字列はrootDir自体を返す。
+ */
+export function resolveSubscribeRoots(
+  rootDir: string,
+  prefixes: string[]
+): string[] {
+  return prefixes.map((prefix) =>
+    prefix === '' ? rootDir : path.join(rootDir, prefix)
+  );
+}


### PR DESCRIPTION
## Summary

- `files.include` パターンの静的プレフィックスを抽出し、`@parcel/watcher` の `subscribe()` をプレフィックスごとに実行。スコープ外ディレクトリのinotify走査を排除
- `buildWatchTargets()` を純粋関数として抽出し、仕様テスト28件追加
- commonIgnores拡充（`.pnpm-store`, `.yarn`, `.uv`, `__pycache__`等）

## Test plan

- [x] extractDirectoryPrefixes ユニットテスト（14件）
- [x] buildWatchTargets 仕様テスト（14件）: subscribeルート決定、`docs/**` vs `docs/*` の2層協調、ignoreパターン構成
- [x] FileWatcher 統合テスト（7件）: 既存テスト全パス
- [ ] Docker環境での実測（CPU消費改善の確認）

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)