### PR TITLE
fix: PR #100 Copilotレビュー指摘対応

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -48,18 +48,22 @@ jobs:
           node -e "const pkg = require('./package.json'); pkg.version = '${{ steps.version.outputs.version }}'; require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
 
       - name: Commit and push changes
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           if git diff --cached --quiet; then
             echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             git commit -m "chore: version packages to v${{ steps.version.outputs.version }}"
             git push
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Pull Request
+        if: steps.commit.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -2090,9 +2090,9 @@ systems/ → app-a/docs/ → deep
 
 **テストファイル**: `packages/server/src/discovery/__tests__/watch-targets.test.ts`
 
-**テストケース**（全25テスト）:
-- ✅ パターン解析（analyzePattern）: 14テスト
-- ✅ WatchTargets構築（buildWatchTargets）: 11テスト
+**テストケース**:
+- ✅ パターン解析（analyzePattern）: deep/shallow判定、globプレフィックス抽出、特殊ケースを網羅
+- ✅ WatchTargets構築（buildWatchTargets）: deep/shallow分離、glob展開、複合パターン、除外処理、重複排除を網羅
 
 ### 関連ドキュメント
 

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1815,145 +1815,6 @@ Facebook製の高性能ファイル監視デーモン。
 
 ---
 
-## ADR-019: files.sources リネームとツリーウォーク監視
-
-**日付**: 2026-05-07
-**状態**: 採用
-**決定者**: 実装チーム
-**関連**: Issue #99, PR #100
-
-### コンテキスト
-
-Issue #97で`files.include`パターンのスコープ最適化を検討した際、以下の課題が明らかになった：
-
-1. **意味的な問題**: `include`という名称は「どのファイルをインデックス化するか」を定義するが、ファイルウォッチャーの監視対象は「どのディレクトリをウォッチするか」も含むため、意味が曖昧。
-2. **パフォーマンス問題**: `docs/**/*.md`のような深い再帰パターンと、`*.md`のような直下のみのパターンが同じ扱いで、無駄な監視が発生。
-3. **glob展開の必要性**: `systems/*/docs/**`のような中間globパターンを、ファイルウォッチャーが正しく扱えない。
-
-### 検討した選択肢
-
-#### 1. include のまま最適化を実装（採用しない）
-
-**内容**: `include`という名称を維持しつつ、内部実装でパターン解析とツリーウォークを実装。
-
-**短所**:
-- `include`という名称は「包含条件」を連想させ、「監視対象ソース」という意味が伝わりにくい
-- 設定ファイルの意図が不明確
-
-#### 2. sources にリネーム + ツリーウォーク（採用）
-
-**内容**:
-- `files.include` → `files.sources` にリネーム
-- `sources`は「監視対象のソースパターン」という明確な意味
-- パターンの `**` 有無で shallow/deep 監視を自動判定するツリーウォーク方式を導入
-- 後方互換として `include` を `sources` にマッピング
-
-**長所**:
-- 設定ファイルの意図が明確（「どのソースを監視するか」）
-- パターン解析により無駄な監視を削減
-- glob中間パターンを実ディレクトリに展開
-- 後方互換により既存プロジェクトが壊れない
-
-### 決定
-
-`files.include` → `files.sources` にリネームし、ツリーウォークベースのshallow/deep監視を実装。
-
-**理由**:
-1. **意味の明確化**: `sources`は「監視対象のソース」という明確な意味
-2. **パフォーマンス向上**: shallow/deep分離により無駄な監視を削減
-3. **柔軟性**: glob中間パターンを実ディレクトリに展開
-4. **後方互換**: 既存の`include`も動作維持
-
-### 実装内容
-
-#### 1. sources リネーム
-
-**変更ファイル**:
-- `packages/types/src/config.ts`: `FilesConfig.include` → `FilesConfig.sources`
-- `packages/types/src/config/loader.ts`: 後方互換マッピング
-- `packages/types/src/config/validator.ts`: `sources` + `include` 両方バリデーション
-
-**後方互換マッピング**:
-```typescript
-if (config.files?.include && !config.files.sources) {
-  config.files.sources = config.files.include;
-}
-```
-
-#### 2. ツリーウォーク方式の3層構造
-
-```
-Layer 0: ツリーウォーク（buildWatchTargets）
-  パターン解析 + ディレクトリ走査で deep/shallow subscription を決定。
-  shallow root には全サブディレクトリを ignore に追加。
-
-Layer 1: @parcel/watcher subscription
-  deep root: 再帰監視（COMMON_IGNORES + exclude のみ）
-  shallow root: 直下ファイルのみ（全サブディレクトリを ignore）
-
-Layer 2: shouldProcessFile（精密フィルタ）
-  sources パターンの minimatch + .md 拡張子チェック。
-```
-
-**実装ファイル**:
-- `packages/server/src/discovery/include-scope.ts`:
-  - `analyzePattern()`: パターン解析（deep/shallow判定）
-  - `buildWatchTargets()`: WatchTarget構築（ツリーウォーク）
-  - `COMMON_IGNORES`: 共通除外パターン
-- `packages/server/src/discovery/file-watcher.ts`: 複数subscription対応
-
-#### 3. shallow/deep 判定ルール
-
-| パターン | 判定 | 意味 |
-|---------|------|------|
-| `docs/**` | deep | docs/ 以下を再帰的に監視 |
-| `docs/**/*.md` | deep | 同上 |
-| `*.md` | shallow | ルート直下のみ |
-| `docs/*` | shallow | docs/ 直下のみ |
-| `README.md` | shallow | ルート直下の特定ファイル |
-
-#### 4. glob プレフィックス解決
-
-`systems/*/docs/**` のように中間に glob を含むパターンは、ディレクトリ走査で実パスを解決:
-
-```
-systems/ → app-a/docs/ → deep
-        → app-b/docs/ → deep
-```
-
-### 影響
-
-**ポジティブ**:
-- 設定ファイルの意図が明確になる
-- shallow/deep分離により監視対象が最適化
-- glob中間パターンに対応
-- 後方互換により既存プロジェクトが壊れない
-
-**ネガティブ**:
-- 設定ファイルの書き方が変わる（ただし後方互換あり）
-- ツリーウォークのディスクI/Oコスト（起動時のみ）
-
-**トレードオフ**:
-- 設定ファイルの変更（新規推奨: `sources`） vs 意味の明確化
-- ツリーウォークのI/O vs 無駄な監視の削減
-
-### テスト
-
-**テストファイル**: `packages/server/src/discovery/__tests__/include-scope.test.ts`
-
-**テストケース**（全25テスト）:
-- ✅ パターン解析（analyzePattern）: 14テスト
-- ✅ WatchTargets構築（buildWatchTargets）: 11テスト
-
-### 関連ドキュメント
-
-- 詳細設計: `docs/file-watcher-design.md`
-- 実装: `packages/server/src/discovery/include-scope.ts`
-- 関連Issue: #99
-- 関連PR: #100
-
----
-
 ## ADR-018: CoreML GPU最適化のための静的形状オーバーライド
 
 **日付**: 2026-04-27
@@ -2100,3 +1961,142 @@ CUDAExecutionProvider あり   → 単一動的セッション（CUDA）
 - [ONNX Runtime CoreML Execution Provider](https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html)
 - [SessionOptions.add_free_dimension_override_by_name](https://onnxruntime.ai/docs/api/python/api_summary.html#sessionoptions)
 - task38: Embedding ONNX化 + Ollama API互換（`prompts/tasks/task38.onnx-migration-ollama-api.v1.md`）
+
+---
+
+## ADR-019: files.sources リネームとツリーウォーク監視
+
+**日付**: 2026-05-07
+**状態**: 採用
+**決定者**: 実装チーム
+**関連**: Issue #99, PR #100
+
+### コンテキスト
+
+Issue #97で`files.include`パターンのスコープ最適化を検討した際、以下の課題が明らかになった：
+
+1. **意味的な問題**: `include`という名称は「どのファイルをインデックス化するか」を定義するが、ファイルウォッチャーの監視対象は「どのディレクトリをウォッチするか」も含むため、意味が曖昧。
+2. **パフォーマンス問題**: `docs/**/*.md`のような深い再帰パターンと、`*.md`のような直下のみのパターンが同じ扱いで、無駄な監視が発生。
+3. **glob展開の必要性**: `systems/*/docs/**`のような中間globパターンを、ファイルウォッチャーが正しく扱えない。
+
+### 検討した選択肢
+
+#### 1. include のまま最適化を実装（採用しない）
+
+**内容**: `include`という名称を維持しつつ、内部実装でパターン解析とツリーウォークを実装。
+
+**短所**:
+- `include`という名称は「包含条件」を連想させ、「監視対象ソース」という意味が伝わりにくい
+- 設定ファイルの意図が不明確
+
+#### 2. sources にリネーム + ツリーウォーク（採用）
+
+**内容**:
+- `files.include` → `files.sources` にリネーム
+- `sources`は「監視対象のソースパターン」という明確な意味
+- パターンの `**` 有無で shallow/deep 監視を自動判定するツリーウォーク方式を導入
+- 後方互換として `include` を `sources` にマッピング
+
+**長所**:
+- 設定ファイルの意図が明確（「どのソースを監視するか」）
+- パターン解析により無駄な監視を削減
+- glob中間パターンを実ディレクトリに展開
+- 後方互換により既存プロジェクトが壊れない
+
+### 決定
+
+`files.include` → `files.sources` にリネームし、ツリーウォークベースのshallow/deep監視を実装。
+
+**理由**:
+1. **意味の明確化**: `sources`は「監視対象のソース」という明確な意味
+2. **パフォーマンス向上**: shallow/deep分離により無駄な監視を削減
+3. **柔軟性**: glob中間パターンを実ディレクトリに展開
+4. **後方互換**: 既存の`include`も動作維持
+
+### 実装内容
+
+#### 1. sources リネーム
+
+**変更ファイル**:
+- `packages/types/src/config.ts`: `FilesConfig.include` → `FilesConfig.sources`
+- `packages/types/src/config/loader.ts`: 後方互換マッピング
+- `packages/types/src/config/validator.ts`: `sources` + `include` 両方バリデーション
+
+**後方互換マッピング**:
+```typescript
+if (config.files?.include && !config.files.sources) {
+  config.files.sources = config.files.include;
+}
+```
+
+#### 2. ツリーウォーク方式の3層構造
+
+```
+Layer 0: ツリーウォーク（buildWatchTargets）
+  パターン解析 + ディレクトリ走査で deep/shallow subscription を決定。
+  shallow root には全サブディレクトリを ignore に追加。
+
+Layer 1: @parcel/watcher subscription
+  deep root: 再帰監視（COMMON_IGNORES + exclude のみ）
+  shallow root: 直下ファイルのみ（全サブディレクトリを ignore）
+
+Layer 2: shouldProcessFile（精密フィルタ）
+  sources パターンの minimatch + .md 拡張子チェック。
+```
+
+**実装ファイル**:
+- `packages/server/src/discovery/watch-targets.ts`:
+  - `analyzePattern()`: パターン解析（deep/shallow判定）
+  - `buildWatchTargets()`: WatchTarget構築（ツリーウォーク）
+  - `COMMON_IGNORES`: 共通除外パターン
+- `packages/server/src/discovery/file-watcher.ts`: 複数subscription対応
+
+#### 3. shallow/deep 判定ルール
+
+| パターン | 判定 | 意味 |
+|---------|------|------|
+| `docs/**` | deep | docs/ 以下を再帰的に監視 |
+| `docs/**/*.md` | deep | 同上 |
+| `*.md` | shallow | ルート直下のみ |
+| `docs/*` | shallow | docs/ 直下のみ |
+| `README.md` | shallow | ルート直下の特定ファイル |
+
+#### 4. glob プレフィックス解決
+
+`systems/*/docs/**` のように中間に glob を含むパターンは、ディレクトリ走査で実パスを解決:
+
+```
+systems/ → app-a/docs/ → deep
+        → app-b/docs/ → deep
+```
+
+### 影響
+
+**ポジティブ**:
+- 設定ファイルの意図が明確になる
+- shallow/deep分離により監視対象が最適化
+- glob中間パターンに対応
+- 後方互換により既存プロジェクトが壊れない
+
+**ネガティブ**:
+- 設定ファイルの書き方が変わる（ただし後方互換あり）
+- ツリーウォークのディスクI/Oコスト（起動時のみ）
+
+**トレードオフ**:
+- 設定ファイルの変更（新規推奨: `sources`） vs 意味の明確化
+- ツリーウォークのI/O vs 無駄な監視の削減
+
+### テスト
+
+**テストファイル**: `packages/server/src/discovery/__tests__/watch-targets.test.ts`
+
+**テストケース**（全25テスト）:
+- ✅ パターン解析（analyzePattern）: 14テスト
+- ✅ WatchTargets構築（buildWatchTargets）: 11テスト
+
+### 関連ドキュメント
+
+- 詳細設計: `docs/file-watcher-design.md`
+- 実装: `packages/server/src/discovery/watch-targets.ts`
+- 関連Issue: #99
+- 関連PR: #100

--- a/docs/file-watcher-design.md
+++ b/docs/file-watcher-design.md
@@ -254,11 +254,9 @@ SearchDocsServer.deleteDocument(path)
 - ✅ サブディレクトリのファイルも検出できる
 - ✅ 停止後はイベントを検出しない
 
-**テストケース（watch-targets.test.ts）**（全25テスト）:
-- ✅ パターン解析（analyzePattern）: 14テスト
-  - deep/shallow判定、globプレフィックス抽出、特殊ケース
-- ✅ WatchTargets構築（buildWatchTargets）: 11テスト
-  - deep/shallow分離、glob展開、複合パターン、除外処理
+**テストケース（watch-targets.test.ts）**:
+- ✅ パターン解析（analyzePattern）: deep/shallow判定、globプレフィックス抽出、特殊ケースを網羅
+- ✅ WatchTargets構築（buildWatchTargets）: deep/shallow分離、glob展開、複合パターン、除外処理、重複排除を網羅
 
 ## 後方互換
 

--- a/docs/file-watcher-design.md
+++ b/docs/file-watcher-design.md
@@ -243,7 +243,7 @@ SearchDocsServer.deleteDocument(path)
 
 **テストファイル**:
 - `packages/server/src/discovery/__tests__/file-watcher.test.ts`
-- `packages/server/src/discovery/__tests__/include-scope.test.ts`
+- `packages/server/src/discovery/__tests__/watch-targets.test.ts`
 
 **テストケース（file-watcher.test.ts）**（全7テスト）:
 - ✅ ファイル追加を検出できる
@@ -254,7 +254,7 @@ SearchDocsServer.deleteDocument(path)
 - ✅ サブディレクトリのファイルも検出できる
 - ✅ 停止後はイベントを検出しない
 
-**テストケース（include-scope.test.ts）**（全25テスト）:
+**テストケース（watch-targets.test.ts）**（全25テスト）:
 - ✅ パターン解析（analyzePattern）: 14テスト
   - deep/shallow判定、globプレフィックス抽出、特殊ケース
 - ✅ WatchTargets構築（buildWatchTargets）: 11テスト
@@ -285,10 +285,10 @@ Issue #99で `files.include` → `files.sources` にリネームされました�
   - [ADR-019](./architecture-decisions.md#adr-019-files-sources-リネームとツリーウォーク監視) - sources リネーム + ツリーウォーク
 - **実装ファイル**:
   - `packages/server/src/discovery/file-watcher.ts`
-  - `packages/server/src/discovery/include-scope.ts`
+  - `packages/server/src/discovery/watch-targets.ts`
 - **テストファイル**:
   - `packages/server/src/discovery/__tests__/file-watcher.test.ts`
-  - `packages/server/src/discovery/__tests__/include-scope.test.ts`
+  - `packages/server/src/discovery/__tests__/watch-targets.test.ts`
 - **関連Issue/PR**:
   - Issue #99: files.include → files.sources リネーム + shallow/deep ツリーウォーク監視
   - PR #100: 実装完了

--- a/packages/mcp-server/src/__tests__/deprecations.test.ts
+++ b/packages/mcp-server/src/__tests__/deprecations.test.ts
@@ -9,7 +9,8 @@ describe('checkConfigDeprecations', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].field).toBe('files.include');
-    expect(result[0].message).toContain('非推奨');
+    expect(result[0].message).toContain('リネーム');
+    expect(result[0].currentValue).toEqual(['**/*.md']);
   });
 
   it('sources あり → 警告なし', () => {

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -67,9 +67,16 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
           statusText += `プロジェクト: ${systemState.config?.project.name}\n\n`;
 
           if (systemState.deprecations && systemState.deprecations.length > 0) {
+            statusText += '⚠️ 非推奨設定の検出:\n\n';
             for (const dep of systemState.deprecations) {
-              statusText += `⚠️  ${dep.message}\n`;
-              statusText += `   ${dep.migration}\n\n`;
+              statusText += `  ${dep.message}\n`;
+              statusText += `  ${dep.migration}\n`;
+              if (dep.currentValue) {
+                const valueStr = JSON.stringify(dep.currentValue);
+                statusText += `\n  修正方法（${systemState.configPath ?? '設定ファイル'}）:\n`;
+                statusText += `    "include": ${valueStr}  →  "sources": ${valueStr}\n`;
+              }
+              statusText += '\n';
             }
           }
 

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -71,10 +71,10 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
             for (const dep of systemState.deprecations) {
               statusText += `  ${dep.message}\n`;
               statusText += `  ${dep.migration}\n`;
-              if (dep.currentValue) {
+              if (dep.currentValue !== undefined) {
                 const valueStr = JSON.stringify(dep.currentValue);
                 statusText += `\n  修正方法（${systemState.configPath ?? '設定ファイル'}）:\n`;
-                statusText += `    "include": ${valueStr}  →  "sources": ${valueStr}\n`;
+                statusText += `    "files": { "include": ${valueStr} }  →  "files": { "sources": ${valueStr} }\n`;
               }
               statusText += '\n';
             }

--- a/packages/server/src/discovery/__tests__/watch-targets.test.ts
+++ b/packages/server/src/discovery/__tests__/watch-targets.test.ts
@@ -35,10 +35,10 @@ function mockFsOps(
   dirTree: Record<string, { name: string; isDirectory: boolean }[]>,
 ): FileSystemOps {
   return {
-    readdir(dir: string) {
+    async readdir(dir: string) {
       return dirTree[dir] ?? [];
     },
-    isDirectory(dir: string) {
+    async isDirectory(dir: string) {
       // dirTreeのキーとして存在するか、
       // 親ディレクトリのエントリに含まれているかで判定
       if (dirTree[dir] !== undefined) return true;
@@ -157,13 +157,13 @@ describe('buildWatchTargets', () => {
   // A. subscribeルートの決定
 
   describe('subscribe ルートの決定', () => {
-    it('単一 deep パターン → そのディレクトリを deep subscribe', () => {
+    it('単一 deep パターン → そのディレクトリを deep subscribe', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('src')],
         [`${ROOT}/docs`]: [file('README.md')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
 
       expect(targets).toHaveLength(1);
       expect(targets[0]).toMatchObject({
@@ -172,14 +172,14 @@ describe('buildWatchTargets', () => {
       });
     });
 
-    it('独立した複数 deep パターン → 複数 deep subscribe', () => {
+    it('独立した複数 deep パターン → 複数 deep subscribe', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('blog')],
         [`${ROOT}/docs`]: [],
         [`${ROOT}/blog`]: [],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['docs/**', 'blog/**']),
         fs,
@@ -193,26 +193,26 @@ describe('buildWatchTargets', () => {
       ]);
     });
 
-    it('ルートパターン（**/*.md）→ ルート全体を deep subscribe', () => {
+    it('ルートパターン（**/*.md）→ ルート全体を deep subscribe', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('src')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['**/*.md']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['**/*.md']), fs);
 
       const deepTargets = targets.filter(t => t.depth === 'deep');
       expect(deepTargets).toHaveLength(1);
       expect(deepTargets[0].root).toBe(ROOT);
     });
 
-    it('包含関係のある deep パターン → 親に集約', () => {
+    it('包含関係のある deep パターン → 親に集約', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [dir('api')],
         [`${ROOT}/docs/api`]: [],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['docs/**', 'docs/api/**']),
         fs,
@@ -233,13 +233,13 @@ describe('buildWatchTargets', () => {
      * shallowの実現方法: 全サブディレクトリを ignorePaths に追加。
      */
 
-    it('docs/** は deep subscription を生成', () => {
+    it('docs/** は deep subscription を生成', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [dir('sub'), file('README.md')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
 
       expect(targets).toHaveLength(1);
       expect(targets[0]).toMatchObject({
@@ -249,13 +249,13 @@ describe('buildWatchTargets', () => {
       });
     });
 
-    it('docs/* は shallow subscription を生成（サブディレクトリを ignorePaths に追加）', () => {
+    it('docs/* は shallow subscription を生成（サブディレクトリを ignorePaths に追加）', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [dir('sub'), dir('guides'), file('README.md')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['docs/*']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['docs/*']), fs);
 
       expect(targets).toHaveLength(1);
       expect(targets[0]).toMatchObject({
@@ -270,14 +270,14 @@ describe('buildWatchTargets', () => {
       );
     });
 
-    it('deep + shallow 混在 → 両方のターゲットを生成', () => {
+    it('deep + shallow 混在 → 両方のターゲットを生成', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('blog'), file('README.md')],
         [`${ROOT}/docs`]: [dir('sub')],
         [`${ROOT}/blog`]: [dir('2024')],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['docs/**', 'blog/*', '*.md']),
         fs,
@@ -303,7 +303,7 @@ describe('buildWatchTargets', () => {
     // systems/{*}/docs/{**} のように中間に glob を含むパターンは、
     // ディレクトリを走査して実パスを解決する。
 
-    it('systems/*/docs/** → 各サブプロジェクトの docs/ を deep subscribe', () => {
+    it('systems/*/docs/** → 各サブプロジェクトの docs/ を deep subscribe', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('systems')],
         [`${ROOT}/systems`]: [dir('app-a'), dir('app-b'), file('README.md')],
@@ -313,7 +313,7 @@ describe('buildWatchTargets', () => {
         [`${ROOT}/systems/app-b/docs`]: [],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['systems/*/docs/**']),
         fs,
@@ -326,12 +326,12 @@ describe('buildWatchTargets', () => {
       ]);
     });
 
-    it('存在しないディレクトリはスキップ', () => {
+    it('存在しないディレクトリはスキップ', async () => {
       const fs = mockFsOps({
         [ROOT]: [],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['nonexistent/**']),
         fs,
@@ -344,24 +344,24 @@ describe('buildWatchTargets', () => {
   // D. ignore パターンの構成
 
   describe('ignore パターンの構成', () => {
-    it('exclude 空 → COMMON_IGNORES のみ', () => {
+    it('exclude 空 → COMMON_IGNORES のみ', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
 
       expect(targets[0].ignorePatterns).toEqual([...COMMON_IGNORES]);
     });
 
-    it('exclude 指定 → COMMON_IGNORES + ユーザー設定', () => {
+    it('exclude 指定 → COMMON_IGNORES + ユーザー設定', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['docs/**'], ['**/drafts/**']),
         fs,
@@ -383,12 +383,12 @@ describe('buildWatchTargets', () => {
   // E. shallow の ignorePaths
 
   describe('shallow の ignorePaths', () => {
-    it('shallow root の全サブディレクトリを ignorePaths に含める', () => {
+    it('shallow root の全サブディレクトリを ignorePaths に含める', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('blog'), dir('src'), dir('tools'), file('README.md')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['*.md']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['*.md']), fs);
 
       const shallowTarget = targets.find(t => t.depth === 'shallow');
       expect(shallowTarget).toBeDefined();
@@ -404,13 +404,13 @@ describe('buildWatchTargets', () => {
       expect(shallowTarget!.ignorePaths).not.toContain(`${ROOT}/README.md`);
     });
 
-    it('deep root は ignorePaths を持たない', () => {
+    it('deep root は ignorePaths を持たない', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs')],
         [`${ROOT}/docs`]: [dir('sub'), dir('guides')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['docs/**']), fs);
 
       const deepTarget = targets.find(t => t.depth === 'deep');
       expect(deepTarget!.ignorePaths).toEqual([]);
@@ -420,14 +420,14 @@ describe('buildWatchTargets', () => {
   // F. 結合検証
 
   describe('結合検証', () => {
-    it('Issue #99 の代表例: docs/** + blog/* + *.md', () => {
+    it('Issue #99 の代表例: docs/** + blog/* + *.md', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('blog'), dir('src'), dir('tools'), file('README.md')],
         [`${ROOT}/docs`]: [dir('sub'), file('guide.md')],
         [`${ROOT}/blog`]: [dir('2024'), file('post.md')],
       });
 
-      const targets = buildWatchTargets(
+      const targets = await buildWatchTargets(
         ROOT,
         makeConfig(['docs/**', 'blog/*', '*.md'], ['src/**']),
         fs,
@@ -463,12 +463,51 @@ describe('buildWatchTargets', () => {
       expect(blogShallow.ignorePaths).toEqual([`${ROOT}/blog/2024`]);
     });
 
-    it('デフォルト設定（**/*.md）→ ルート全体を deep subscribe', () => {
+    it('deep + shallow 同一ディレクトリ → deep が優先（重複排除）', async () => {
+      const fs = mockFsOps({
+        [ROOT]: [dir('docs')],
+        [`${ROOT}/docs`]: [dir('sub'), file('README.md')],
+      });
+
+      const targets = await buildWatchTargets(
+        ROOT,
+        makeConfig(['docs/**', 'docs/*']),
+        fs,
+      );
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]).toMatchObject({
+        root: `${ROOT}/docs`,
+        depth: 'deep',
+      });
+    });
+
+    it('deep 親が shallow 子を包含 → shallow は生成されない', async () => {
+      const fs = mockFsOps({
+        [ROOT]: [dir('docs'), dir('src')],
+        [`${ROOT}/docs`]: [dir('api'), file('README.md')],
+        [`${ROOT}/docs/api`]: [file('guide.md')],
+      });
+
+      const targets = await buildWatchTargets(
+        ROOT,
+        makeConfig(['docs/**', 'docs/api/*']),
+        fs,
+      );
+
+      const deep = targets.filter(t => t.depth === 'deep');
+      const shallow = targets.filter(t => t.depth === 'shallow');
+      expect(deep).toHaveLength(1);
+      expect(deep[0].root).toBe(`${ROOT}/docs`);
+      expect(shallow).toHaveLength(0);
+    });
+
+    it('デフォルト設定（**/*.md）→ ルート全体を deep subscribe', async () => {
       const fs = mockFsOps({
         [ROOT]: [dir('docs'), dir('src')],
       });
 
-      const targets = buildWatchTargets(ROOT, makeConfig(['**/*.md']), fs);
+      const targets = await buildWatchTargets(ROOT, makeConfig(['**/*.md']), fs);
 
       expect(targets).toHaveLength(1);
       expect(targets[0]).toMatchObject({

--- a/packages/server/src/discovery/file-discovery.ts
+++ b/packages/server/src/discovery/file-discovery.ts
@@ -68,7 +68,7 @@ export class FileDiscovery {
    */
   matchesPattern(filePath: string): boolean {
     // sourcesパターンにマッチするか
-    const matchesInclude = this.config.sources.some((pattern) => {
+    const matchesSources = this.config.sources.some((pattern) => {
       // minimatchはfast-globと異なり、**/patternがルートレベルにマッチしない
       // fast-globの挙動に合わせるため、**/で始まるパターンは
       // ルートレベルとネストレベルの両方をチェック
@@ -79,7 +79,7 @@ export class FileDiscovery {
       return minimatch(filePath, pattern);
     });
 
-    if (!matchesInclude) {
+    if (!matchesSources) {
       return false;
     }
 

--- a/packages/server/src/discovery/file-watcher.ts
+++ b/packages/server/src/discovery/file-watcher.ts
@@ -40,7 +40,7 @@ export class FileWatcher extends EventEmitter {
   }
 
   async start(): Promise<void> {
-    const targets = buildWatchTargets(this.rootDir, this.filesConfig);
+    const targets = await buildWatchTargets(this.rootDir, this.filesConfig);
 
     const callback: watcher.SubscribeCallback = (err, events) => {
       if (err) {

--- a/packages/server/src/discovery/watch-targets.ts
+++ b/packages/server/src/discovery/watch-targets.ts
@@ -90,9 +90,16 @@ const defaultFsOps: FileSystemOps = {
   async readdir(dir: string) {
     try {
       const entries = await fs.readdir(dir, { withFileTypes: true });
-      return entries.map(entry => ({
-        name: entry.name,
-        isDirectory: entry.isDirectory(),
+      return Promise.all(entries.map(async entry => {
+        let isDir = entry.isDirectory();
+        if (!isDir && entry.isSymbolicLink()) {
+          try {
+            isDir = (await fs.stat(path.join(dir, entry.name))).isDirectory();
+          } catch {
+            // リンク先が壊れている場合はファイル扱い
+          }
+        }
+        return { name: entry.name, isDirectory: isDir };
       }));
     } catch {
       return [];

--- a/packages/server/src/discovery/watch-targets.ts
+++ b/packages/server/src/discovery/watch-targets.ts
@@ -162,9 +162,11 @@ export async function buildWatchTargets(
   for (const root of shallowRoots) {
     if (!await ops.isDirectory(root)) continue;
 
-    const coveredByDeep = dedupedDeepRoots.some(
-      deepRoot => root === deepRoot || root.startsWith(deepRoot + '/'),
-    );
+    const coveredByDeep = dedupedDeepRoots.some(deepRoot => {
+      if (root === deepRoot) return true;
+      const rel = path.relative(deepRoot, root);
+      return rel !== '' && !rel.startsWith('..');
+    });
     if (coveredByDeep) continue;
 
     const entries = await ops.readdir(root);

--- a/packages/server/src/discovery/watch-targets.ts
+++ b/packages/server/src/discovery/watch-targets.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 import type { FilesConfig } from '@search-docs/types';
 
 export const COMMON_IGNORES = [
@@ -82,38 +82,36 @@ export function analyzePattern(pattern: string): PatternAnalysis {
 }
 
 export interface FileSystemOps {
-  readdir(dir: string): { name: string; isDirectory: boolean }[];
-  isDirectory(dir: string): boolean;
+  readdir(dir: string): Promise<{ name: string; isDirectory: boolean }[]>;
+  isDirectory(dir: string): Promise<boolean>;
 }
 
 const defaultFsOps: FileSystemOps = {
-  readdir(dir: string) {
+  async readdir(dir: string) {
     try {
-      return fs.readdirSync(dir).map(name => {
-        try {
-          return { name, isDirectory: fs.statSync(path.join(dir, name)).isDirectory() };
-        } catch {
-          return { name, isDirectory: false };
-        }
-      });
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      return entries.map(entry => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+      }));
     } catch {
       return [];
     }
   },
-  isDirectory(dir: string) {
+  async isDirectory(dir: string) {
     try {
-      return fs.statSync(dir).isDirectory();
+      return (await fs.stat(dir)).isDirectory();
     } catch {
       return false;
     }
   },
 };
 
-export function buildWatchTargets(
+export async function buildWatchTargets(
   rootDir: string,
   filesConfig: FilesConfig,
   fsOps?: FileSystemOps,
-): WatchTarget[] {
+): Promise<WatchTarget[]> {
   const ops = fsOps ?? defaultFsOps;
 
   // パターン解析
@@ -127,7 +125,7 @@ export function buildWatchTargets(
   const deepRoots = new Set<string>();
 
   for (const analysis of deepAnalyses) {
-    const resolvedPaths = resolveSubscribeRoots(rootDir, analysis, ops);
+    const resolvedPaths = await resolveSubscribeRoots(rootDir, analysis, ops);
     resolvedPaths.forEach(p => deepRoots.add(p));
   }
 
@@ -138,7 +136,7 @@ export function buildWatchTargets(
   const shallowRoots = new Set<string>();
 
   for (const analysis of shallowAnalyses) {
-    const resolvedPaths = resolveSubscribeRoots(rootDir, analysis, ops);
+    const resolvedPaths = await resolveSubscribeRoots(rootDir, analysis, ops);
     resolvedPaths.forEach(p => shallowRoots.add(p));
   }
 
@@ -150,7 +148,7 @@ export function buildWatchTargets(
 
   // deep targets
   for (const root of dedupedDeepRoots) {
-    if (!ops.isDirectory(root)) continue;
+    if (!await ops.isDirectory(root)) continue;
 
     targets.push({
       root,
@@ -160,11 +158,16 @@ export function buildWatchTargets(
     });
   }
 
-  // shallow targets
+  // shallow targets（deep に包含されるものは除外）
   for (const root of shallowRoots) {
-    if (!ops.isDirectory(root)) continue;
+    if (!await ops.isDirectory(root)) continue;
 
-    const entries = ops.readdir(root);
+    const coveredByDeep = dedupedDeepRoots.some(
+      deepRoot => root === deepRoot || root.startsWith(deepRoot + '/'),
+    );
+    if (coveredByDeep) continue;
+
+    const entries = await ops.readdir(root);
     const ignorePaths = entries
       .filter(e => e.isDirectory)
       .map(e => path.join(root, e.name));
@@ -180,11 +183,11 @@ export function buildWatchTargets(
   return targets;
 }
 
-function resolveSubscribeRoots(
+async function resolveSubscribeRoots(
   rootDir: string,
   analysis: PatternAnalysis,
   ops: FileSystemOps,
-): string[] {
+): Promise<string[]> {
   const { staticPrefix, pattern, type } = analysis;
 
   if (!staticPrefix) {
@@ -212,11 +215,11 @@ function resolveSubscribeRoots(
   return walkToResolve(prefixPath, middleSegments, ops);
 }
 
-function walkToResolve(
+async function walkToResolve(
   basePath: string,
   segments: string[],
   ops: FileSystemOps,
-): string[] {
+): Promise<string[]> {
   if (segments.length === 0) {
     return [basePath];
   }
@@ -224,11 +227,11 @@ function walkToResolve(
   const [current, ...rest] = segments;
 
   if (current === '*') {
-    const entries = ops.readdir(basePath);
+    const entries = await ops.readdir(basePath);
     const results: string[] = [];
     for (const entry of entries) {
       if (entry.isDirectory) {
-        results.push(...walkToResolve(path.join(basePath, entry.name), rest, ops));
+        results.push(...await walkToResolve(path.join(basePath, entry.name), rest, ops));
       }
     }
     return results;

--- a/packages/types/src/config/loader.ts
+++ b/packages/types/src/config/loader.ts
@@ -9,6 +9,7 @@ export interface ConfigDeprecation {
   field: string;
   message: string;
   migration: string;
+  currentValue?: unknown;
 }
 
 export function checkConfigDeprecations(rawConfig: unknown): ConfigDeprecation[] {
@@ -20,8 +21,9 @@ export function checkConfigDeprecations(rawConfig: unknown): ConfigDeprecation[]
       if (f.include !== undefined && f.sources === undefined) {
         deprecations.push({
           field: 'files.include',
-          message: 'files.include は非推奨です。files.sources に変更してください。',
-          migration: '設定ファイルの "files"."include" を "files"."sources" にリネームしてください。',
+          message: '"files"."include" は v1.9.0 で "files"."sources" にリネームされました。',
+          migration: '設定ファイルの "include" キーを "sources" に変更してください。後方互換は維持されていますが、将来のバージョンで削除予定です。',
+          currentValue: f.include,
         });
       }
     }

--- a/packages/types/src/config/loader.ts
+++ b/packages/types/src/config/loader.ts
@@ -22,7 +22,7 @@ export function checkConfigDeprecations(rawConfig: unknown): ConfigDeprecation[]
         deprecations.push({
           field: 'files.include',
           message: '"files"."include" は v1.9.0 で "files"."sources" にリネームされました。',
-          migration: '設定ファイルの "include" キーを "sources" に変更してください。後方互換は維持されていますが、将来のバージョンで削除予定です。',
+          migration: '設定ファイルの "files"."include" を "files"."sources" に変更してください。後方互換は維持されていますが、将来のバージョンで削除予定です。',
           currentValue: f.include,
         });
       }


### PR DESCRIPTION
## Summary

PR #100 マージ後に届いた Copilot レビュー (10件) への対応。

### コード改善
- **readdirSync withFileTypes 最適化**: `fs.statSync()` の N回呼び出しを `fs.readdirSync(dir, { withFileTypes: true })` + `Dirent.isDirectory()` に置き換え
- **deep/shallow 重複 WatchTarget 排除**: 同一ディレクトリが deep と shallow 両方の root になる場合に deep を優先して shallow を除外（二重 subscribe 防止）
- **変数名リネーム**: `matchesInclude` → `matchesSources`（file-discovery.ts）

### 非推奨警告メッセージの改善
- 設定ファイルパスと before/after の具体例を表示
- `ConfigDeprecation` に `currentValue` フィールドを追加

### ドキュメント修正
- `include-scope.ts/test` → `watch-targets.ts/test` のファイル名参照修正（5箇所）
- ADR-019 の配置順序を ADR-018 の後に修正

### CI
- release-prepare: コミットスキップ時に PR 作成もスキップする条件分岐を追加

## Test plan
- [x] watch-targets テスト通過（27件、重複排除テスト2件追加）
- [x] deprecations テスト通過（5件、currentValue 検証追加）
- [x] types / server / mcp-server ビルドOK

Closes: PR #100 review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)