### PR TITLE
fix: onnxruntime 1.25.1 更新 + モデルパス解決修正

### DIFF
--- a/.changeset/onnxruntime-upgrade.md
+++ b/.changeset/onnxruntime-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@search-docs/db-engine": patch
+---
+
+onnxruntime を 1.20.0 → 1.25.1 に更新。CoreML EP の input dim > 16384 制限が解消され、embedding 層（語彙サイズ 102400）が GPU 実行可能に（494/624 → 599/624 ノード対応）。モデルパス解決からプロジェクトキャッシュ参照を削除。

--- a/packages/db-engine/pyproject.toml
+++ b/packages/db-engine/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "pyarrow==22.0.0",
     "pandas==2.3.3",
     "numpy==2.3.5",
-    "onnxruntime==1.20.0",
+    "onnxruntime==1.25.1",
     "transformers==4.57.1",
     "huggingface-hub==0.36.0",
     "protobuf==6.33.1",

--- a/packages/db-engine/src/python/embedding_server.py
+++ b/packages/db-engine/src/python/embedding_server.py
@@ -156,7 +156,7 @@ class EmbeddingRequestHandler(BaseHTTPRequestHandler):
 
 
 def resolve_onnx_model_path() -> str:
-    """ONNXモデルのパスを解決。Docker → プロジェクトキャッシュ → HuggingFace Hub"""
+    """ONNXモデルのパスを解決。Docker → HuggingFace Hub"""
     import os
 
     # 1. Docker内蔵パス
@@ -164,12 +164,7 @@ def resolve_onnx_model_path() -> str:
     if os.path.exists(os.path.join(docker_path, 'onnx', 'model.onnx')):
         return docker_path
 
-    # 2. プロジェクトキャッシュ（cwd/.cache/models/）
-    project_path = os.path.join(os.getcwd(), '.cache', 'models', 'ruri-v3-30m-onnx')
-    if os.path.exists(os.path.join(project_path, 'onnx', 'model.onnx')):
-        return project_path
-
-    # 3. HuggingFace Hubからダウンロード
+    # 2. HuggingFace Hubからダウンロード（キャッシュ済みなら即時返却）
     from huggingface_hub import snapshot_download
     sys.stderr.write("[EmbeddingServer] Downloading ONNX model from HuggingFace Hub...\n")
     sys.stderr.flush()


### PR DESCRIPTION
## Summary

- onnxruntime を 1.20.0 → 1.25.1 に更新
- CoreML EP の `input dim > 16384` 制限が解消され、embedding層の語彙テーブル（102400×256）が GPU 実行可能に
  - 対応ノード数: 494/624 → 599/624（ADR-018 検証時の数値と一致）
- `resolve_onnx_model_path()` からプロジェクトキャッシュ（`cwd/.cache/models/`）参照を削除
  - `search-docs embedding start` はプロジェクト横断で利用する設計のため、cwd依存のパスは不適切

## Test plan

- [ ] `uv sync` でインストール確認
- [ ] CoreML 環境でモデルロード → `input dim > 16384` 警告が出ないこと
- [ ] 599/624 ノードが CoreML に対応すること
- [ ] HuggingFace Hub からのモデルダウンロードが正常動作すること
- [ ] Docker 環境でのビルド・動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)