### PR TITLE
fix: SQLフィルタのシングルクォートエスケープ

### DIFF
--- a/packages/db-engine/src/__tests__/db-engine.test.ts
+++ b/packages/db-engine/src/__tests__/db-engine.test.ts
@@ -278,6 +278,64 @@ describe('DBEngine', () => {
     });
   });
 
+  describe('シングルクォートを含むパスの操作', () => {
+    const quotedPath = "/test/app's-notes/document.md";
+    const quotedHash = 'hash-quoted';
+
+    it('シングルクォートを含むパスでセクションを追加・取得できる', async () => {
+      await engine.addSections([{
+        id: 'quoted-section-1',
+        documentPath: quotedPath,
+        heading: "App's Notes",
+        depth: 1,
+        content: 'シングルクォートを含むパスのテスト',
+        tokenCount: 10,
+        parentId: null,
+        order: 0,
+        isDirty: false,
+        documentHash: quotedHash,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        startLine: 1,
+        endLine: 5,
+        sectionNumber: [1],
+      }]);
+
+      const result = await engine.getSectionsByPath(quotedPath);
+      expect(result.sections.length).toBe(1);
+      expect(result.sections[0].documentPath).toBe(quotedPath);
+    });
+
+    it('シングルクォートを含むパスでDirtyマークできる', async () => {
+      const result = await engine.markDirty(quotedPath);
+      expect(result.marked).toBe(true);
+    });
+
+    it('シングルクォートを含むパスでfindSectionsByPathAndHashできる', async () => {
+      const result = await engine.findSectionsByPathAndHash(quotedPath, quotedHash);
+      expect(result.length).toBe(1);
+    });
+
+    it('シングルクォートを含むパスでIndexRequestを操作できる', async () => {
+      const created = await engine.createIndexRequest({
+        documentPath: quotedPath,
+        documentHash: quotedHash,
+      });
+      expect(created.documentPath).toBe(quotedPath);
+
+      const found = await engine.findIndexRequests({ documentPath: quotedPath });
+      expect(found.length).toBeGreaterThan(0);
+    });
+
+    it('シングルクォートを含むパスでセクションを削除できる', async () => {
+      const result = await engine.deleteSectionsByPath(quotedPath);
+      expect(result.deleted).toBe(true);
+
+      const remaining = await engine.getSectionsByPath(quotedPath);
+      expect(remaining.sections.length).toBe(0);
+    });
+  });
+
   describe('Section拡張操作', () => {
     const testPath = '/test/hash-test.md';
     const hashV1 = 'hash-v1';

--- a/packages/db-engine/src/python/worker.py
+++ b/packages/db-engine/src/python/worker.py
@@ -64,6 +64,11 @@ from utils.batch_utils import create_token_aware_batches, get_batch_stats
 from utils.section_filter import filter_sections_by_token_limit, get_texts_to_encode
 
 
+def _escape_sql(value: str) -> str:
+    """SQLリテラル用にシングルクォートをエスケープ"""
+    return value.replace("'", "''")
+
+
 class PerformanceLogger:
     """パフォーマンスログを定期的に出力するクラス"""
 
@@ -937,14 +942,14 @@ class SearchDocsWorker:
         if include_paths:
             # パス包含フィルタ（前方一致、OR形式）
             # 例: document_path LIKE 'docs/%' OR document_path LIKE 'README.md%'
-            path_conditions = [f"document_path LIKE '{path}%'" for path in include_paths]
+            path_conditions = [f"document_path LIKE '{_escape_sql(path)}%'" for path in include_paths]
             filters.append(f"({' OR '.join(path_conditions)})")
 
         if exclude_paths:
             # パス除外フィルタ（前方一致、AND形式）
             # 例: document_path NOT LIKE 'docs/internal/%' AND document_path NOT LIKE 'temp/%'
             for path in exclude_paths:
-                filters.append(f"document_path NOT LIKE '{path}%'")
+                filters.append(f"document_path NOT LIKE '{_escape_sql(path)}%'")
 
         if filters:
             search_query = search_query.where(" AND ".join(filters))
@@ -982,7 +987,7 @@ class SearchDocsWorker:
             raise ValueError("documentPath parameter is required")
 
         table = self._get_sections_table()
-        results = table.search().where(f"document_path = '{document_path}'").to_list()
+        results = table.search().where(f"document_path = '{_escape_sql(document_path)}'").to_list()
 
         # 結果をフォーマット
         formatted_sections = [self.format_section(section) for section in results]
@@ -996,7 +1001,7 @@ class SearchDocsWorker:
             raise ValueError("sectionId parameter is required")
 
         table = self._get_sections_table()
-        results = table.search().where(f"id = '{section_id}'").to_list()
+        results = table.search().where(f"id = '{_escape_sql(section_id)}'").to_list()
 
         if not results:
             raise ValueError(f"Section not found: {section_id}")
@@ -1010,7 +1015,7 @@ class SearchDocsWorker:
             raise ValueError("documentPath parameter is required")
 
         table = self._get_sections_table()
-        table.delete(f"document_path = '{document_path}'")
+        table.delete(f"document_path = '{_escape_sql(document_path)}'")
         self._maybe_optimize(table,"sections")
 
         return {"deleted": True}
@@ -1032,7 +1037,7 @@ class SearchDocsWorker:
         limit = params.get("limit", 1)
 
         results = table.search()\
-            .where(f"document_path = '{document_path}' AND document_hash = '{document_hash}'")\
+            .where(f"document_path = '{_escape_sql(document_path)}' AND document_hash = '{_escape_sql(document_hash)}'")\
             .limit(limit)\
             .to_list()
 
@@ -1054,7 +1059,7 @@ class SearchDocsWorker:
         table = self._get_sections_table()
 
         # 指定したhash以外を削除
-        table.delete(f"document_path = '{document_path}' AND document_hash != '{document_hash}'")
+        table.delete(f"document_path = '{_escape_sql(document_path)}' AND document_hash != '{_escape_sql(document_hash)}'")
         self._maybe_optimize(table,"sections")
 
         return {"deleted": True}
@@ -1068,7 +1073,7 @@ class SearchDocsWorker:
         table = self._get_sections_table()
         # LanceDBの更新操作
         table.update(
-            where=f"document_path = '{document_path}'",
+            where=f"document_path = '{_escape_sql(document_path)}'",
             values={"is_dirty": True}
         )
         self._maybe_optimize(table,"sections")
@@ -1169,19 +1174,19 @@ class SearchDocsWorker:
         where_clauses = []
 
         if "document_path" in params:
-            where_clauses.append(f"document_path = '{params['document_path']}'")
+            where_clauses.append(f"document_path = '{_escape_sql(params['document_path'])}'")
 
         if "document_hash" in params:
-            where_clauses.append(f"document_hash = '{params['document_hash']}'")
+            where_clauses.append(f"document_hash = '{_escape_sql(params['document_hash'])}'")
 
         if "status" in params:
             status = params["status"]
             if isinstance(status, list):
                 # 複数のstatusをORで結合
-                status_clauses = [f"status = '{s}'" for s in status]
+                status_clauses = [f"status = '{_escape_sql(s)}'" for s in status]
                 where_clauses.append(f"({' OR '.join(status_clauses)})")
             else:
-                where_clauses.append(f"status = '{status}'")
+                where_clauses.append(f"status = '{_escape_sql(status)}'")
 
         # クエリの実行
         query = table.search()
@@ -1228,19 +1233,19 @@ class SearchDocsWorker:
         where_clauses = []
 
         if "document_path" in params:
-            where_clauses.append(f"document_path = '{params['document_path']}'")
+            where_clauses.append(f"document_path = '{_escape_sql(params['document_path'])}'")
 
         if "document_hash" in params:
-            where_clauses.append(f"document_hash = '{params['document_hash']}'")
+            where_clauses.append(f"document_hash = '{_escape_sql(params['document_hash'])}'")
 
         if "status" in params:
             status = params["status"]
             if isinstance(status, list):
                 # 複数のstatusをORで結合
-                status_clauses = [f"status = '{s}'" for s in status]
+                status_clauses = [f"status = '{_escape_sql(s)}'" for s in status]
                 where_clauses.append(f"({' OR '.join(status_clauses)})")
             else:
-                where_clauses.append(f"status = '{status}'")
+                where_clauses.append(f"status = '{_escape_sql(status)}'")
 
         # count_rows()を使用（インデックスが利用される）
         if where_clauses:
@@ -1271,13 +1276,13 @@ class SearchDocsWorker:
 
         # 更新実行
         table.update(
-            where=f"id = '{request_id}'",
+            where=f"id = '{_escape_sql(request_id)}'",
             values=updates
         )
         self._maybe_optimize(table,"index_requests")
 
         # 更新後のオブジェクトを取得して返す
-        df = table.search().where(f"id = '{request_id}'").limit(1).to_pandas()
+        df = table.search().where(f"id = '{_escape_sql(request_id)}'").limit(1).to_pandas()
         if len(df) == 0:
             raise ValueError(f"Request not found after update: {request_id}")
 
@@ -1307,10 +1312,10 @@ class SearchDocsWorker:
         where_clauses = []
 
         if "document_path" in filter_params:
-            where_clauses.append(f"document_path = '{filter_params['document_path']}'")
+            where_clauses.append(f"document_path = '{_escape_sql(filter_params['document_path'])}'")
 
         if "status" in filter_params:
-            where_clauses.append(f"status = '{filter_params['status']}'")
+            where_clauses.append(f"status = '{_escape_sql(filter_params['status'])}'")
 
         if "created_at" in filter_params:
             created_at = filter_params["created_at"]
@@ -1350,7 +1355,7 @@ class SearchDocsWorker:
         table = self._get_index_requests_table()
 
         # statusフィルタの構築
-        status_clauses = [f"status = '{s}'" for s in statuses]
+        status_clauses = [f"status = '{_escape_sql(s)}'" for s in statuses]
         where_str = " OR ".join(status_clauses)
 
         # クエリ実行（document_pathカラムのみ取得でメモリ効率化）

--- a/packages/db-engine/src/python/worker.py
+++ b/packages/db-engine/src/python/worker.py
@@ -69,6 +69,14 @@ def _escape_sql(value: str) -> str:
     return value.replace("'", "''")
 
 
+def _escape_like(value: str) -> str:
+    """LIKE句用にメタ文字とシングルクォートをエスケープ"""
+    escaped = value.replace("'", "''")
+    escaped = escaped.replace("%", "\\%")
+    escaped = escaped.replace("_", "\\_")
+    return escaped
+
+
 class PerformanceLogger:
     """パフォーマンスログを定期的に出力するクラス"""
 
@@ -942,14 +950,14 @@ class SearchDocsWorker:
         if include_paths:
             # パス包含フィルタ（前方一致、OR形式）
             # 例: document_path LIKE 'docs/%' OR document_path LIKE 'README.md%'
-            path_conditions = [f"document_path LIKE '{_escape_sql(path)}%'" for path in include_paths]
+            path_conditions = [f"document_path LIKE '{_escape_like(path)}%'" for path in include_paths]
             filters.append(f"({' OR '.join(path_conditions)})")
 
         if exclude_paths:
             # パス除外フィルタ（前方一致、AND形式）
             # 例: document_path NOT LIKE 'docs/internal/%' AND document_path NOT LIKE 'temp/%'
             for path in exclude_paths:
-                filters.append(f"document_path NOT LIKE '{_escape_sql(path)}%'")
+                filters.append(f"document_path NOT LIKE '{_escape_like(path)}%'")
 
         if filters:
             search_query = search_query.where(" AND ".join(filters))


### PR DESCRIPTION
*🤖 by Claude Code*

## Summary

- ファイルパスにシングルクォートを含むドキュメントのインデックス時にLanceDBのSQLフィルタが壊れる問題を修正
- `_escape_sql()` ヘルパー関数を追加し、`worker.py` 内の全SQL文字列リテラル埋め込み箇所（21箇所）でシングルクォートを `''` にエスケープ
- `document_path`, `document_hash`, `id`, `status`, LIKE句のパスを網羅的に対応

## Test plan

- [x] Python構文チェック通過
- [x] db-engine テスト全23件パス
- [ ] シングルクォートを含むファイルパスでの動作確認

refs #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)