### PR TITLE
feat: MCPリソース追加とdescription/メッセージ整理

### DIFF
--- a/.changeset/mcp-resources-and-description.md
+++ b/.changeset/mcp-resources-and-description.md
@@ -1,0 +1,10 @@
+---
+"@search-docs/mcp-server": minor
+---
+
+feat: MCPリソース追加とdescription/メッセージ整理 (#108)
+
+- MCPサーバーにinstructionsを追加（サーバー接続時にシステムプロンプトに表示）
+- MCPリソース4種を実装: getting-started, architecture, usage, config-reference
+- NOT_CONFIGURED時のメッセージを改善し、関連プロジェクトが利用可能であることを明示
+- 全ツールのdescriptionをコンパクトに簡素化、詳細はMCPリソースへ誘導

--- a/packages/mcp-server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/mcp-server/src/__tests__/server-lifecycle.test.ts
@@ -38,7 +38,7 @@ describe('MCP Server ライフサイクルテスト', () => {
       const content = (result.result as MCPToolResult)?.content?.[0]?.text;
 
       expect(content).toContain('✅ 設定ファイルの初期化が完了しました');
-      expect(content).toContain('📝 設定ファイルの重要な項目');
+      expect(content).toContain('設定リファレンス');
     });
   });
 

--- a/packages/mcp-server/src/__tests__/server-state.test.ts
+++ b/packages/mcp-server/src/__tests__/server-state.test.ts
@@ -55,7 +55,7 @@ describe('MCP Server 状態確認テスト', () => {
       const content = (result.result as MCPToolResult)?.content?.[0]?.text;
 
       expect(content).toBeDefined();
-      expect(content).toContain('状態: 未設定');
+      expect(content).toContain('状態: ローカルプロジェクト未設定');
     });
   });
 

--- a/packages/mcp-server/src/__tests__/state.test.ts
+++ b/packages/mcp-server/src/__tests__/state.test.ts
@@ -121,7 +121,7 @@ describe('state', () => {
       const message = getStateErrorMessage('NOT_CONFIGURED', '検索');
 
       expect(message).toContain('検索を実行できません');
-      expect(message).toContain('セットアップされていません');
+      expect(message).toContain('ローカルプロジェクトが設定されていない');
       expect(message).toContain('init');
       expect(message).toContain('add_related_project');
     });

--- a/packages/mcp-server/src/resources/architecture.ts
+++ b/packages/mcp-server/src/resources/architecture.ts
@@ -45,13 +45,11 @@ MCP Server (stdio)
 
 ## Docker構成
 
-DockerイメージはMCPサーバとして動作します。WatcherProcessを内蔵し、Embeddingサーバを自動検出・起動します。
+1イメージ・2モード:
+- **MCPサーバモード**（デフォルト）: WatcherProcess内蔵。Embeddingサーバを自動検出し、見つからなければコンテナ内でCPU起動
+- **Embeddingサーバモード**（\`--mode=embedding-server\`）: 複数MCPサーバから共有利用。メモリ節約に有効
 
-GPU（CoreML/Metal）を活用する場合は、Embeddingサーバをホスト側で起動し、Docker MCPサーバーから接続します:
-\`\`\`
-ホスト: search-docs embedding start
-Docker: EMBEDDING_URL=http://host.docker.internal:24281
-\`\`\`
+GPU/CoreMLアクセラレーションを使う場合は、ホスト側で \`search-docs embedding start\` を起動。Docker MCPサーバが \`host.docker.internal\` 経由で自動検出します。
 
 ## データモデル
 

--- a/packages/mcp-server/src/resources/architecture.ts
+++ b/packages/mcp-server/src/resources/architecture.ts
@@ -45,9 +45,13 @@ MCP Server (stdio)
 
 ## Docker構成
 
-1イメージ・2モード:
-- **MCPサーバモード**（デフォルト）: WatcherProcess内蔵、Embedding自動検出・起動
-- **Embeddingサーバモード**（\`--mode=embedding-server\`）: HTTPで待ち受け、複数MCPサーバから共有利用
+DockerイメージはMCPサーバとして動作します。WatcherProcessを内蔵し、Embeddingサーバを自動検出・起動します。
+
+GPU（CoreML/Metal）を活用する場合は、Embeddingサーバをホスト側で起動し、Docker MCPサーバーから接続します:
+\`\`\`
+ホスト: search-docs embedding start
+Docker: EMBEDDING_URL=http://host.docker.internal:24281
+\`\`\`
 
 ## データモデル
 

--- a/packages/mcp-server/src/resources/architecture.ts
+++ b/packages/mcp-server/src/resources/architecture.ts
@@ -1,0 +1,58 @@
+export const ARCHITECTURE_CONTENT = `# アーキテクチャ概要
+
+## プロセス構成
+
+\`\`\`
+MCP Server (stdio)
+  ├─ in-process: SearchDocsServer (read-only)
+  ├─ in-process: WatcherProcess (write, heartbeat調停)
+  ├─ in-process: DBEngine
+  └─ subprocess: Embedding Server (stateless, 共有可能)
+           │
+           ▼
+       LanceDB (共有ストレージ)
+\`\`\`
+
+## コンポーネント
+
+### MCP Server
+- Claude Code統合、stdio通信
+- SearchDocsServerをin-processで直接保持（HTTPデーモン不要）
+- SearchDocsServiceインターフェイス経由でサーバ機能を利用
+
+### JSON-RPC Server（search-docs server）
+- \`search-docs server start\` コマンドで起動するHTTPサーバ
+- 外部クライアントやrelated project接続向け
+- MCPサーバからは使用されない（MCPはin-processで動作）
+
+### Write Worker（WatcherProcess）
+- ファイル監視（FileWatcher）とインデックス更新（IndexWorker）を担当
+- Heartbeat調停により、複数インスタンス間で1つだけがmasterとして動作
+- master以外はstandbyで待機し、masterがダウンすると自動昇格
+
+### Embedding API Server
+- Ollama API互換のHTTP埋め込みサーバ
+- モデル: Ruri Embedding (cl-nagoya/ruri-v3-30m)
+- ステートレスで複数プロセスから共有利用可能
+- 自動検出: 外部URL → Docker service → host.docker.internal → ローカルspawn
+
+### CLI
+- \`server\`: サーバの起動・停止・状態確認・再起動
+- \`search\`: 文書の検索（JSON/テーブル出力対応）
+- \`index\`: インデックスの再構築・状態確認
+- \`embedding\`: Embeddingサーバの起動・停止・状態確認
+- \`config\`: 設定ファイルの初期化
+
+## Docker構成
+
+1イメージ・2モード:
+- **MCPサーバモード**（デフォルト）: WatcherProcess内蔵、Embedding自動検出・起動
+- **Embeddingサーバモード**（\`--mode=embedding-server\`）: HTTPで待ち受け、複数MCPサーバから共有利用
+
+## データモデル
+
+- **Document**: パス形式のキーで管理されるMarkdown文書
+- **Section**: 見出し（H1-H4）ベースで分割。depth 0-3、トークン数閾値で再帰分割
+- **SearchIndex**: LanceDB + Ruri Embeddingによるベクトル検索
+- **Dirty管理**: 文書変更時にセクションをdirtyマーク → バックグラウンドワーカーが順次更新
+`;

--- a/packages/mcp-server/src/resources/config-reference.ts
+++ b/packages/mcp-server/src/resources/config-reference.ts
@@ -1,0 +1,150 @@
+export const CONFIG_REFERENCE_CONTENT = `# 設定リファレンス
+
+設定ファイルは \`.search-docs/config.json\` または \`.search-docs.json\` に配置します。
+
+## project
+
+\`\`\`json
+{
+  "project": {
+    "name": "my-project",
+    "root": "."
+  }
+}
+\`\`\`
+
+- \`name\`: プロジェクト名
+- \`root\`: プロジェクトルートディレクトリ（通常は \`.\`）
+
+## files
+
+\`\`\`json
+{
+  "files": {
+    "sources": ["**/*.md"],
+    "exclude": ["**/node_modules/**"],
+    "ignoreGitignore": true
+  }
+}
+\`\`\`
+
+- \`sources\`: 監視対象のglobパターン（推奨、v1.8.6以降）
+- \`include\`: \`sources\`の旧名称（後方互換あり、非推奨）
+- \`exclude\`: 除外するglobパターン
+- \`ignoreGitignore\`: \`.gitignore\` のパターンを尊重するか
+
+**監視方式の自動判定**:
+- \`**\` を含むパターン → deep（再帰的に監視）
+- \`**\` を含まないパターン → shallow（直下のみ監視）
+- 中間globパターン（例: \`systems/*/docs/**\`）→ 起動時に実パスに展開
+
+## indexing
+
+\`\`\`json
+{
+  "indexing": {
+    "maxTokensPerSection": 2000,
+    "minTokensForSplit": 100,
+    "maxDepth": 3,
+    "vectorDimension": 256,
+    "embeddingModel": "cl-nagoya/ruri-v3-30m",
+    "embeddingUrl": "http://localhost:24281"
+  }
+}
+\`\`\`
+
+- \`maxTokensPerSection\`: セクションの最大トークン数（デフォルト: 2000）
+- \`minTokensForSplit\`: 分割する最小トークン数（デフォルト: 100）
+- \`maxDepth\`: 最大分割深度 0-3（デフォルト: 3）
+- \`vectorDimension\`: ベクトル次元数（デフォルト: 256）
+- \`embeddingModel\`: 埋め込みモデル名
+- \`embeddingUrl\`: 外部Embeddingサーバの指定（省略時は自動検出・起動）
+
+## search
+
+\`\`\`json
+{
+  "search": {
+    "defaultLimit": 10,
+    "maxLimit": 100,
+    "includeCleanOnly": false
+  }
+}
+\`\`\`
+
+- \`defaultLimit\`: デフォルトの検索結果数
+- \`maxLimit\`: 最大検索結果数
+- \`includeCleanOnly\`: Cleanなセクションのみ検索するか
+
+## server
+
+\`\`\`json
+{
+  "server": {
+    "host": "localhost",
+    "port": 24280,
+    "protocol": "json-rpc"
+  }
+}
+\`\`\`
+
+## storage
+
+\`\`\`json
+{
+  "storage": {
+    "documentsPath": ".search-docs/documents",
+    "indexPath": ".search-docs/index",
+    "cachePath": ".search-docs/cache"
+  }
+}
+\`\`\`
+
+通常は変更不要です。
+
+## watcher
+
+\`\`\`json
+{
+  "watcher": {
+    "enabled": true,
+    "debounceMs": 1000
+  }
+}
+\`\`\`
+
+- \`enabled\`: ファイル監視を有効にするか
+- \`debounceMs\`: 変更検知の遅延時間（ミリ秒）
+
+## worker
+
+\`\`\`json
+{
+  "worker": {
+    "enabled": true,
+    "interval": 5000,
+    "maxConcurrent": 3
+  }
+}
+\`\`\`
+
+- \`enabled\`: ワーカーを有効にするか
+- \`interval\`: 処理間隔（ミリ秒）
+- \`maxConcurrent\`: 最大同時処理数
+
+## relatedProjects
+
+\`\`\`json
+{
+  "relatedProjects": {
+    "other-project": {
+      "url": "http://localhost:24281",
+      "description": "関連プロジェクト"
+    }
+  }
+}
+\`\`\`
+
+関連プロジェクトのsearch-docsサーバに接続して横断検索が可能です。
+ランタイム追加は \`add_related_project\` ツールで行えます（セッション限り）。
+`;

--- a/packages/mcp-server/src/resources/getting-started.ts
+++ b/packages/mcp-server/src/resources/getting-started.ts
@@ -1,0 +1,47 @@
+export const GETTING_STARTED_CONTENT = `# search-docsをはじめる
+
+## セットアップ
+
+### 方法1: Claude Code + Docker版（推奨）
+
+\`\`\`bash
+claude mcp add search-docs -- docker run --rm -i \\
+  -v .:/workspace:ro \\
+  -v ./.search-docs:/workspace/.search-docs \\
+  otolab/search-docs-mcp:latest
+\`\`\`
+
+### 方法2: Claude Code + npx版
+
+\`\`\`bash
+claude mcp add search-docs -- npx -y @search-docs/mcp-server
+\`\`\`
+
+### 方法3: CLIツール
+
+\`\`\`bash
+npx @search-docs/cli config init
+npx @search-docs/cli server start
+npx @search-docs/cli search "検索クエリ"
+\`\`\`
+
+## 設定ファイルの初期化
+
+MCPツールの \`init\` を実行すると \`.search-docs/config.json\` が作成されます。
+
+主な設定項目:
+- **files.sources**: 監視対象のglobパターン（デフォルト: \`["**/*.md"]\`）
+- **indexing.maxDepth**: セクション分割の最大深度（0-3、デフォルト: 3）
+- **indexing.maxTokensPerSection**: セクションの最大トークン数（デフォルト: 2000）
+
+詳しくは設定リファレンス（\`search-docs://config-reference\`）を参照してください。
+
+## initなしで使う
+
+設定ファイルがなくても、\`add_related_project\` で他プロジェクトのsearch-docsサーバに接続し、検索できます。
+
+\`\`\`
+add_related_project(name: "other-project", url: "http://localhost:24280")
+search(query: "検索キーワード", project: "other-project")
+\`\`\`
+`;

--- a/packages/mcp-server/src/resources/index.ts
+++ b/packages/mcp-server/src/resources/index.ts
@@ -1,0 +1,58 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { GETTING_STARTED_CONTENT } from './getting-started.js';
+import { ARCHITECTURE_CONTENT } from './architecture.js';
+import { USAGE_CONTENT } from './usage.js';
+import { CONFIG_REFERENCE_CONTENT } from './config-reference.js';
+
+interface ResourceDefinition {
+  name: string;
+  uri: string;
+  description: string;
+  content: string;
+}
+
+const RESOURCES: ResourceDefinition[] = [
+  {
+    name: 'search-docsをはじめる',
+    uri: 'search-docs://getting-started',
+    description: 'セットアップ手順と設定ファイルの書き方',
+    content: GETTING_STARTED_CONTENT,
+  },
+  {
+    name: 'アーキテクチャ概要',
+    uri: 'search-docs://architecture',
+    description: 'プロセス構成・Embedding・Worker・Docker・CLI',
+    content: ARCHITECTURE_CONTENT,
+  },
+  {
+    name: 'search-docsの使い方',
+    uri: 'search-docs://usage',
+    description: '検索・文書取得・アウトラインの効果的な使い方',
+    content: USAGE_CONTENT,
+  },
+  {
+    name: '設定リファレンス',
+    uri: 'search-docs://config-reference',
+    description: '.search-docs.jsonの全オプション解説',
+    content: CONFIG_REFERENCE_CONTENT,
+  },
+];
+
+export function registerResources(server: McpServer): void {
+  for (const resource of RESOURCES) {
+    server.resource(
+      resource.name,
+      resource.uri,
+      { description: resource.description, mimeType: 'text/markdown' },
+      () => ({
+        contents: [
+          {
+            uri: resource.uri,
+            mimeType: 'text/markdown',
+            text: resource.content,
+          },
+        ],
+      })
+    );
+  }
+}

--- a/packages/mcp-server/src/resources/usage.ts
+++ b/packages/mcp-server/src/resources/usage.ts
@@ -1,0 +1,79 @@
+export const USAGE_CONTENT = `# search-docsの使い方
+
+## ツール一覧
+
+| ツール | 用途 |
+|--------|------|
+| search | ドキュメントからVector検索 |
+| get_document | セクションまたは文書全体の内容を取得 |
+| get_outline | 文書の目次構造をトークン数付きで表示 |
+| index_status | インデックスの詳細状態を確認 |
+| get_system_status | システム全体の状態を確認 |
+| init | 設定ファイルを初期化 |
+| add_related_project | 関連プロジェクトを一時的に追加 |
+| list_related_projects | 関連プロジェクトの一覧を表示 |
+
+## 基本的な検索フロー
+
+### 1. 検索する
+\`\`\`
+search(query: "認証の仕組み")
+\`\`\`
+
+結果にはセクションID、ファイルパス、行範囲、プレビューが含まれます。
+
+### 2. セクションの全文を読む
+\`\`\`
+get_document(sectionId: "検索結果のid")
+\`\`\`
+
+### 3. 文書全体を読む
+\`\`\`
+get_document(path: "docs/auth.md")
+\`\`\`
+
+## 検索のコツ
+
+### depth（検索粒度）
+- \`depth: 0\` — 文書全体のみ（大まかな関連文書を探す）
+- \`depth: 1\` — 章レベルまで（トピック単位で探す）
+- \`depth: 2\` — 節レベルまで（具体的な内容を探す）
+- \`depth: 3\` — 項レベルまで（ピンポイントで探す、デフォルト）
+
+### パスで絞り込み
+\`\`\`
+search(query: "API設計", includePaths: ["docs/"])
+search(query: "テスト", excludePaths: ["docs/internal/"])
+\`\`\`
+
+### 関連プロジェクトの検索
+\`\`\`
+search(query: "検索キーワード", project: "other-project")
+\`\`\`
+
+## ドキュメントのメンテナンス
+
+### 目次で全体像を把握
+\`\`\`
+get_outline(path: "docs/architecture.md")
+\`\`\`
+各セクションのトークン数が表示されるので、記述量のバランスを確認できます。
+
+### インデックス状態の確認
+\`\`\`
+index_status()
+\`\`\`
+Dirtyセクション数でインデックス更新の進捗を確認できます。
+
+## 関連プロジェクト
+
+### ランタイム追加（セッション限り）
+\`\`\`
+add_related_project(name: "other", url: "http://localhost:24280")
+\`\`\`
+
+対象プロジェクトで \`search-docs server start\` を実行してからURLを指定してください。
+
+### 永続化（設定ファイル）
+\`.search-docs/config.json\` の \`relatedProjects\` に記載します。
+`;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -23,6 +23,7 @@ import {
   registerAddRelatedProjectTool,
   type RegisteredTool,
 } from './tools/index.js';
+import { registerResources } from './resources/index.js';
 
 // package.jsonからバージョンを読み込む
 const require = createRequire(import.meta.url);
@@ -168,7 +169,13 @@ async function main() {
     {
       capabilities: {
         tools: {},
+        resources: {},
       },
+      instructions: [
+        'search-docsはプロジェクト内のドキュメントを高速・効率的に検索するシステムです。',
+        'システムの設計や背景知識を探したいときや、ドキュメントのメンテナンス時の作業を強力にアシストします。',
+        '詳しい使い方や設定はこのMCPサーバーのリソース（resources/list）を参照してください。',
+      ].join('\n'),
     }
   );
 
@@ -212,6 +219,9 @@ async function main() {
 
   // ツール登録コンテキスト
   const context = { server, systemState, refreshSystemState, serverManager };
+
+  // リソース登録
+  registerResources(server);
 
   // 全ツールを登録
   debugLog('Registering all tools...');

--- a/packages/mcp-server/src/state.ts
+++ b/packages/mcp-server/src/state.ts
@@ -160,10 +160,11 @@ export function getStateErrorMessage(state: SystemState, action: string, related
   switch (state) {
     case 'NOT_CONFIGURED': {
       let message =
-        `${action}を実行できません。search-docsがまだセットアップされていません。\n\n` +
-        'セットアップ方法:\n' +
-        '  - 設定ファイルを作成: init\n' +
-        '  - 関連プロジェクトを追加: add_related_project\n';
+        `ローカルプロジェクトが設定されていないため、${action}を実行できません。\n\n` +
+        '利用可能なオプション:\n' +
+        '  - ローカルプロジェクトを設定: init\n' +
+        '  - 関連プロジェクトを追加して検索: add_related_project\n' +
+        '  - 詳しくはMCPリソース「search-docsをはじめる」を参照\n';
 
       if (relatedProjectNames && relatedProjectNames.length > 0) {
         message += `\n利用可能な関連プロジェクト: ${relatedProjectNames.join(', ')}\n`;

--- a/packages/mcp-server/src/tools/add-related-project.ts
+++ b/packages/mcp-server/src/tools/add-related-project.ts
@@ -17,8 +17,7 @@ export function registerAddRelatedProjectTool(context: ToolRegistrationContext):
     'add_related_project',
     {
       description:
-        '関連プロジェクトを一時的に追加します。追加されたプロジェクトはセッション中のみ有効で、設定ファイルには保存されません。\n' +
-        '起動済みのsearch-docsサーバに接続します。対象プロジェクトで `search-docs server start` を実行してからURLを指定してください（Docker環境ではlocalhostを自動でhost.docker.internalに補正します）',
+        '関連プロジェクトを一時的に追加します（セッション中のみ有効）。対象プロジェクトの起動済みsearch-docsサーバURLを指定してください。',
       inputSchema: {
         name: z.string().describe('プロジェクト名（一意の識別子）'),
         url: z.string().describe('起動済みサーバのURL（例: http://localhost:<port>）'),

--- a/packages/mcp-server/src/tools/get-document.ts
+++ b/packages/mcp-server/src/tools/get-document.ts
@@ -18,7 +18,7 @@ export function registerGetDocumentTool(context: ToolRegistrationContext): Regis
     'get_document',
     {
       description:
-        '文書の内容を取得します。searchで見つけたセクションの全文を読む場合はsectionIdを、文書全体を読む場合はpathを指定します。コンテンツ全文が返されます。',
+        '文書の内容を取得します。セクションの全文はsectionId、文書全体はpathを指定します。',
       inputSchema: {
         path: z.string().optional().describe('文書パス（sectionIdを指定しない場合は必須）'),
         sectionId: z.string().optional().describe('セクションID（検索結果から取得。pathを指定しない場合は必須）'),

--- a/packages/mcp-server/src/tools/get-outline.ts
+++ b/packages/mcp-server/src/tools/get-outline.ts
@@ -17,7 +17,7 @@ export function registerGetOutlineTool(context: ToolRegistrationContext): Regist
     'get_outline',
     {
       description:
-        '文書の目次構造をトークン数付きで一覧表示します。少ないトークン消費で文書の全体像を把握でき、記述量バランスの確認や読むべきセクションの特定に使えます。各セクションの見出し、行範囲、トークン数、セクションIDが返されます。',
+        '文書の目次構造をトークン数付きで一覧表示します。文書の全体像把握や記述量バランスの確認に使えます。',
       inputSchema: {
         path: z.string().optional().describe('文書パス（sectionIdを指定しない場合は必須）'),
         sectionId: z.string().optional().describe('セクションID（指定した場合、そのセクション配下のみ表示）'),

--- a/packages/mcp-server/src/tools/index-status.ts
+++ b/packages/mcp-server/src/tools/index-status.ts
@@ -50,7 +50,7 @@ export function registerIndexStatusTool(context: ToolRegistrationContext): Regis
     'index_status',
     {
       description:
-        'インデックスの詳細な状態を確認します。文書の更新反映を待っているときや、ワーカーの動作状況を確認したいときに使用します。文書数、セクション数、Dirty数、ワーカー状態が返されます。',
+        'インデックスの詳細な状態を確認します。文書数、セクション数、Dirty数、ワーカー状態が返されます。',
       inputSchema: {
         project: z
           .string()

--- a/packages/mcp-server/src/tools/init.ts
+++ b/packages/mcp-server/src/tools/init.ts
@@ -17,7 +17,7 @@ export function registerInitTool(context: ToolRegistrationContext): RegisteredTo
     'init',
     {
       description:
-        'search-docsの設定ファイルを初期化します。プロジェクトで初めてsearch-docsを使用する際に実行してください。主要な設定項目の説明と次のステップが返されます。',
+        'search-docsの設定ファイルを初期化します。ローカルプロジェクトの文書を検索対象にする場合に実行してください。',
       inputSchema: {
         port: z
           .number()
@@ -49,27 +49,11 @@ export function registerInitTool(context: ToolRegistrationContext): RegisteredTo
           resultText += '既存の設定ファイルを上書きしました。\n\n';
         }
 
-        resultText += '📝 設定ファイルの重要な項目:\n\n';
-        resultText += '**files.sources**: ドキュメントソースのパターン\n';
-        resultText += '  - デフォルト: ["**/*.md", "docs/**/*.txt"]\n';
-        resultText += '  - ** を含むパターン → 再帰監視（deep）\n';
-        resultText += '  - ** を含まないパターン → 直下のみ監視（shallow）\n\n';
-        resultText += '**files.exclude**: 除外するファイルパターン\n';
-        resultText += '  - デフォルト: node_modules, .git, dist, buildを除外\n';
-        resultText += '  - 必要に応じて追加してください\n\n';
-        resultText += '**indexing.maxDepth**: セクション分割の最大深度（0-3）\n';
-        resultText += '  - 0: 文書全体のみ\n';
-        resultText += '  - 1: 章レベルまで分割\n';
-        resultText += '  - 2: 節レベルまで分割\n';
-        resultText += '  - 3: 項レベルまで分割（デフォルト）\n\n';
-        resultText += '**indexing.maxTokensPerSection**: セクションの最大トークン数\n';
-        resultText += '  - デフォルト: 2000トークン\n';
-        resultText += '  - 大きくすると粗い分割、小さくすると細かい分割になります\n\n';
         resultText += '次のステップ:\n';
         resultText += '  1. 設定を調整（必要に応じて）: .search-docs/config.json を編集\n';
-        resultText += '  2. **Claude Codeを再接続してツールリストを更新**\n';
-        resultText += '  3. システム状態を確認: get_system_status\n';
-        resultText += '  4. 文書を検索: search\n';
+        resultText += '  2. Claude Codeを再接続してツールリストを更新\n';
+        resultText += '  3. システム状態を確認: get_system_status\n\n';
+        resultText += '設定項目の詳細はMCPリソース「設定リファレンス」を参照してください。\n';
 
         return {
           content: [

--- a/packages/mcp-server/src/tools/list-related-projects.ts
+++ b/packages/mcp-server/src/tools/list-related-projects.ts
@@ -15,7 +15,7 @@ export function registerListRelatedProjectsTool(context: ToolRegistrationContext
     'list_related_projects',
     {
       description:
-        '設定ファイルで定義された関連プロジェクトの一覧を取得します。他プロジェクトの文書を検索・参照する前に、利用可能なプロジェクト名を確認するために使用します。各プロジェクトの名前、説明、サーバ起動状態が返されます。',
+        '関連プロジェクトの一覧を取得します。設定ファイルで定義されたものとadd_related_projectで追加されたものの両方を表示します。',
       inputSchema: {},
     },
     async () => {
@@ -25,8 +25,8 @@ export function registerListRelatedProjectsTool(context: ToolRegistrationContext
       const allRelatedProjects = context.serverManager.getAllRelatedProjects(systemState.config?.relatedProjects);
       if (Object.keys(allRelatedProjects).length === 0) {
         resultText += '📋 関連プロジェクト\n\n';
-        resultText += '関連プロジェクトは設定されていません。\n\n';
-        resultText += '設定ファイルで関連プロジェクトを定義することで、複数のプロジェクトを検索できます。\n';
+        resultText += '関連プロジェクトはありません。\n\n';
+        resultText += 'add_related_projectで追加するか、設定ファイルで定義できます。\n';
 
         return {
           content: [

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -18,7 +18,7 @@ export function registerSearchTool(context: ToolRegistrationContext): Registered
     'search',
     {
       description:
-        'プロジェクトのドキュメントから情報を効率的に探せます。Markdown等のインデックス済みファイルからVector検索で関連するセクションが関連性順で返されます。各結果には見出し、セクションID、ファイルパス、行範囲、プレビューが含まれます。',
+        'ドキュメントをVector検索します。関連するセクションが関連性順で返されます。',
       inputSchema: {
         query: z.string().describe('検索クエリ'),
         project: z

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -15,7 +15,7 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
     'get_system_status',
     {
       description:
-        'search-docsの全体状態を確認します。初回セットアップ時や動作確認に使用してください。設定状態、サーバ起動状態、インデックス情報、関連プロジェクト一覧が返されます。',
+        'search-docsの全体状態を確認します。設定状態、インデックス情報、関連プロジェクト一覧が返されます。',
       inputSchema: {},
     },
     async () => {
@@ -23,11 +23,12 @@ export function registerSystemStatusTool(context: ToolRegistrationContext): Regi
 
       switch (systemState.state) {
         case 'NOT_CONFIGURED': {
-          statusText += '状態: 未設定\n\n';
-          statusText += 'search-docsがまだセットアップされていません。\n\n';
-          statusText += 'セットアップ方法:\n';
-          statusText += '  - 設定ファイルを作成: init\n';
-          statusText += '  - 関連プロジェクトを追加: add_related_project（dirでローカル追加、urlで起動済みサーバに接続）\n';
+          statusText += '状態: ローカルプロジェクト未設定\n\n';
+          statusText += 'ローカルプロジェクトは設定されていませんが、関連プロジェクトの追加・検索は利用可能です。\n\n';
+          statusText += '利用可能なオプション:\n';
+          statusText += '  - ローカルプロジェクトを設定: init\n';
+          statusText += '  - 関連プロジェクトを追加: add_related_project\n';
+          statusText += '  - 詳しくはMCPリソース「search-docsをはじめる」を参照\n';
 
           // 一時追加の関連プロジェクトがあれば表示
           const notConfiguredRelated = context.serverManager.getAllRelatedProjects();


### PR DESCRIPTION
## Summary
- MCPサーバーに `instructions` とリソース（resources/list, resources/read）を追加
- ツールのdescription/メッセージを整理し、詳細情報はMCPリソースに移動
- NOT_CONFIGURED時のメッセージを改善（initなしでもadd_related_projectが使えることを明示）

## 変更内容

### MCPリソース追加（新規）
| name | uri | 内容 |
|---|---|---|
| search-docsをはじめる | `search-docs://getting-started` | セットアップ手順と設定ファイルの書き方 |
| アーキテクチャ概要 | `search-docs://architecture` | プロセス構成・Embedding・Worker・Docker・CLI |
| search-docsの使い方 | `search-docs://usage` | 検索・文書取得・アウトラインの効果的な使い方 |
| 設定リファレンス | `search-docs://config-reference` | .search-docs.jsonの全オプション解説 |

### instructions追加
サーバー接続時にシステムプロンプトに以下が表示される:
> search-docsはプロジェクト内のドキュメントを高速・効率的に検索するシステムです。
> システムの設計や背景知識を探したいときや、ドキュメントのメンテナンス時の作業を強力にアシストします。
> 詳しい使い方や設定はこのMCPサーバーのリソース（resources/list）を参照してください。

### description/メッセージ整理
- NOT_CONFIGURED時: 「セットアップされていません」→「ローカルプロジェクト未設定、関連プロジェクトは利用可能」
- 全ツールdescription: コンパクトに簡素化
- init成功メッセージ: 設定詳細を削除しMCPリソースへ誘導
- list_related_projects: ランタイム追加も含む表現に修正

Closes #108

## Test plan
- [x] 型チェック・ビルド通過
- [x] ユニットテスト（state.test.ts等）通過
- [x] MCPプロトコル経由でinstructions/リソース一覧/リソース読み取りを確認
- [x] NOT_CONFIGURED状態でのget_system_status出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)