### PR TITLE
fix: MCPサーバのconsole出力をログファイルにリダイレクト

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -9,6 +9,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { Command } from 'commander';
 import { createRequire } from 'module';
 import * as path from 'path';
+import { setupLogRedirect } from '@search-docs/server';
 
 import { detectSystemState, createService, stopService, type SystemState, type ServiceInstances } from './state.js';
 import { ServerManager } from './server-manager.js';
@@ -135,6 +136,12 @@ async function main() {
 
   // プロジェクトディレクトリを決定
   const cwd = projectDir || process.cwd();
+
+  // ログリダイレクト設定（console.log/error/warnをファイルに転送）
+  const logPath = process.env.SEARCH_DOCS_LOG_PATH
+    || path.join(cwd, '.search-docs', 'server.log');
+  setupLogRedirect(logPath);
+
   debugLog(`Working directory: ${cwd}`);
 
   // システム状態を判定

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,3 +12,4 @@ export { MarkdownSplitter } from './splitter/markdown-splitter.js';
 export { TokenCounter } from './splitter/token-counter.js';
 export { WatcherProcess } from './watcher/watcher-process.js';
 export { EmbeddingServerProcess, type EmbeddingServerOptions } from './embedding/index.js';
+export { setupLogRedirect } from './utils/log-redirect.js';


### PR DESCRIPTION
## Summary
- MCPサーバ経由で動作するEmbeddingServerProcess等の`console.log/error/warn`がstderrに直接出力されていた問題を修正
- JSON-RPCサーバ側と同様に`setupLogRedirect`を適用し、`.search-docs/server.log`にリダイレクト
- `setupLogRedirect`を`@search-docs/server`パッケージからre-export

## Test plan
- [ ] MCPサーバ起動時に`.search-docs/server.log`にログが記録されることを確認
- [ ] `[EmbeddingServer]`のログがstderrではなくログファイルに出力されることを確認
- [ ] stdio通信が壊れないことを確認（`process.stdout.isTTY === false`でコンソール出力なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)