### PR TITLE
feat: LanceDBテーブルの自動修復機能を追加

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@search-docs/client": "workspace:*",
     "@search-docs/config": "workspace:*",
+    "@search-docs/db-engine": "workspace:*",
     "@search-docs/server": "workspace:*",
     "@search-docs/types": "workspace:*",
     "commander": "12.1.0"

--- a/packages/cli/src/commands/maintenance/repair.ts
+++ b/packages/cli/src/commands/maintenance/repair.ts
@@ -1,0 +1,84 @@
+/**
+ * maintenance repair コマンド
+ * LanceDBテーブルの破損を検出・修復する（サーバ不要、DBEngine直接操作）
+ */
+
+import * as path from 'path';
+import { ConfigLoader } from '@search-docs/config';
+import { DBEngine, type RepairTablesResponse } from '@search-docs/db-engine';
+
+export interface MaintenanceRepairOptions {
+  config?: string;
+}
+
+function formatRepairResult(response: RepairTablesResponse): void {
+  console.log('テーブル修復結果:');
+  console.log('');
+
+  for (const [tableName, result] of Object.entries(response.tables)) {
+    const icon = result.status === 'ok' ? '✓' : '⚠';
+    let line = `  ${icon} ${tableName}: ${result.status}`;
+    if (result.action) {
+      line += ` → ${result.action}`;
+    }
+    console.log(line);
+    if (result.error) {
+      console.log(`    エラー: ${result.error}`);
+    }
+  }
+
+  console.log('');
+  if (response.initTablesError) {
+    console.error(`テーブル再初期化エラー: ${response.initTablesError}`);
+  }
+
+  if (response.createdCount) {
+    console.log(`${response.createdCount}個のテーブルを新規作成しました。`);
+  }
+
+  if (response.repairedCount > 0) {
+    console.log(`${response.repairedCount}個の破損テーブルを修復しました。`);
+    console.log('インデックスデータが失われているため、再インデックスが必要です:');
+    console.log('  search-docs index rebuild --force');
+  } else if (!response.createdCount) {
+    console.log('全テーブル正常です。修復の必要はありません。');
+  }
+}
+
+export async function executeMaintenanceRepair(
+  options: MaintenanceRepairOptions
+): Promise<void> {
+  try {
+    const { config, projectRoot } = await ConfigLoader.resolve({
+      cwd: process.cwd(),
+      configPath: options.config,
+    });
+
+    if (!config) {
+      console.error('設定ファイルが見つかりません。先に search-docs config init を実行してください。');
+      process.exit(1);
+    }
+
+    const dbPath = path.resolve(projectRoot, config.storage.indexPath);
+    console.log(`データベースパス: ${dbPath}`);
+    console.log('テーブルの修復を開始します...');
+    console.log('');
+
+    const dbEngine = new DBEngine({
+      dbPath,
+      readOnly: false,
+    });
+
+    await dbEngine.connect({ skipInitModel: true });
+
+    try {
+      const result = await dbEngine.repairTables();
+      formatRepairResult(result);
+    } finally {
+      dbEngine.disconnect();
+    }
+  } catch (error) {
+    console.error('Error:', (error as Error).message);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,5 +222,19 @@ embeddingCmd
   });
 
 
+// maintenance コマンド
+const maintenanceCmd = program
+  .command('maintenance')
+  .description('データベースメンテナンス');
+
+maintenanceCmd
+  .command('repair')
+  .description('LanceDBテーブルの破損を検出・修復')
+  .action(async () => {
+    const { executeMaintenanceRepair } = await import('./commands/maintenance/repair.js');
+    await executeMaintenanceRepair({ config: globalConfigPath });
+  });
+
+
 // コマンドラインを解析
 program.parse(process.argv);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../types" },
     { "path": "../config" },
-    { "path": "../client" }
+    { "path": "../client" },
+    { "path": "../db-engine" }
   ]
 }

--- a/packages/db-engine/src/python/worker.py
+++ b/packages/db-engine/src/python/worker.py
@@ -55,6 +55,7 @@ from schemas import (
     SECTIONS_TABLE,
     INDEX_REQUESTS_TABLE,
     WRITER_HEARTBEAT_TABLE,
+    ALL_TABLES,
     validate_section,
     validate_index_request
 )
@@ -672,6 +673,8 @@ class SearchDocsWorker:
                 result = self.get_writer_heartbeat()
             elif method == "releaseWriter":
                 result = self.release_writer(params)
+            elif method == "repairTables":
+                result = self.repair_tables()
             else:
                 return {
                     "jsonrpc": "2.0",
@@ -1441,6 +1444,53 @@ class SearchDocsWorker:
             return {"success": False, "reason": "not_current_master"}
         table.delete("writer_id IS NOT NULL")
         return {"success": True}
+
+
+    def repair_tables(self) -> Dict[str, Any]:
+        """破損テーブルを検出し、drop→再作成で修復する"""
+        results = {}
+
+        try:
+            existing_tables = self.db.table_names()
+        except Exception as e:
+            sys.stderr.write(f"[Repair] Failed to read table list: {e}\n")
+            sys.stderr.flush()
+            return {"tables": {}, "repairedCount": 0, "initTablesError": f"Failed to read table list: {str(e)}"}
+
+        for table_name in ALL_TABLES:
+            try:
+                if table_name not in existing_tables:
+                    results[table_name] = {"status": "missing", "action": "created"}
+                    continue
+
+                table = self.db.open_table(table_name)
+                table.count_rows()
+                results[table_name] = {"status": "ok"}
+            except Exception as e:
+                error_msg = str(e)
+                sys.stderr.write(f"[Repair] Table {table_name} is corrupted: {error_msg}\n")
+                sys.stderr.flush()
+                try:
+                    self.db.drop_table(table_name)
+                    results[table_name] = {"status": "corrupted", "action": "dropped_and_recreated", "error": error_msg}
+                except Exception as drop_err:
+                    results[table_name] = {"status": "corrupted", "action": "drop_failed", "error": error_msg, "dropError": str(drop_err)}
+                    sys.stderr.write(f"[Repair] Failed to drop {table_name}: {drop_err}\n")
+                    sys.stderr.flush()
+
+        self._sections_table = None
+        self._index_requests_table = None
+
+        try:
+            self.init_tables()
+        except Exception as e:
+            sys.stderr.write(f"[Repair] init_tables failed: {e}\n")
+            sys.stderr.flush()
+            return {"tables": results, "repairedCount": 0, "initTablesError": str(e)}
+
+        repaired_count = sum(1 for r in results.values() if r.get("action") in ("dropped_and_recreated", "drop_failed"))
+        created_count = sum(1 for r in results.values() if r.get("action") == "created")
+        return {"tables": results, "repairedCount": repaired_count, "createdCount": created_count}
 
 
 def main():

--- a/packages/db-engine/src/typescript/index.ts
+++ b/packages/db-engine/src/typescript/index.ts
@@ -101,6 +101,20 @@ export interface StatsResponse {
   totalDocuments: number;
 }
 
+export interface RepairTableResult {
+  status: 'ok' | 'missing' | 'corrupted';
+  action?: 'created' | 'dropped_and_recreated' | 'drop_failed';
+  error?: string;
+  dropError?: string;
+}
+
+export interface RepairTablesResponse {
+  tables: Record<string, RepairTableResult>;
+  repairedCount: number;
+  createdCount?: number;
+  initTablesError?: string;
+}
+
 // Python形式のセクション（snake_case）
 interface PythonSection {
   id: string;
@@ -253,7 +267,7 @@ export class DBEngine extends EventEmitter {
   /**
    * データベースに接続
    */
-  async connect(): Promise<void> {
+  async connect(options?: { skipInitModel?: boolean }): Promise<void> {
     console.log('[DBEngine.connect] Starting connection...');
 
     if (this.worker && this.isReady) {
@@ -465,37 +479,44 @@ export class DBEngine extends EventEmitter {
       throw new Error(String(error));
     }
 
-    // モデルの初期化を確認
-    console.log('[DBEngine.connect] Initializing embedding model...');
-    this.connectionState = 'initializing_model';
-
-    try {
-      const initResult = await this.initModel();
-      if (!initResult.success) {
-        const error = new Error(
-          `Failed to initialize embedding model: ${initResult.model_name}. ` +
-          'Vector search will not function properly. ' +
-          'Please ensure all Python dependencies (protobuf, sentencepiece) are installed.'
-        );
-        this.connectionState = 'error';
-        this.connectionError = error;
-        this.rejectConnected(error);
-        throw error;
-      }
-      console.log(`[DBEngine.connect] Embedding model initialized: ${initResult.model_name} (${initResult.dimension}d)`);
-
-      // 接続完了
+    if (options?.skipInitModel) {
+      // メンテナンス用: embedding model なしで接続完了
+      console.log('[DBEngine.connect] Skipping initModel (maintenance mode)');
       this.connectionState = 'ready';
       this.resolveConnected();
+    } else {
+      // モデルの初期化を確認
+      console.log('[DBEngine.connect] Initializing embedding model...');
+      this.connectionState = 'initializing_model';
 
-      // メモリ監視を開始
-      this.startMemoryMonitoring();
-    } catch (error) {
-      // initModelでエラーが発生した場合
-      this.connectionState = 'error';
-      this.connectionError = error instanceof Error ? error : new Error(String(error));
-      this.rejectConnected(this.connectionError);
-      throw error;
+      try {
+        const initResult = await this.initModel();
+        if (!initResult.success) {
+          const error = new Error(
+            `Failed to initialize embedding model: ${initResult.model_name}. ` +
+            'Vector search will not function properly. ' +
+            'Please ensure all Python dependencies (protobuf, sentencepiece) are installed.'
+          );
+          this.connectionState = 'error';
+          this.connectionError = error;
+          this.rejectConnected(error);
+          throw error;
+        }
+        console.log(`[DBEngine.connect] Embedding model initialized: ${initResult.model_name} (${initResult.dimension}d)`);
+
+        // 接続完了
+        this.connectionState = 'ready';
+        this.resolveConnected();
+
+        // メモリ監視を開始
+        this.startMemoryMonitoring();
+      } catch (error) {
+        // initModelでエラーが発生した場合
+        this.connectionState = 'error';
+        this.connectionError = error instanceof Error ? error : new Error(String(error));
+        this.rejectConnected(this.connectionError);
+        throw error;
+      }
     }
   }
 
@@ -954,7 +975,7 @@ export class DBEngine extends EventEmitter {
   /**
    * JSON-RPCリクエストを送信
    */
-  private async sendRequest(method: string, params?: unknown): Promise<unknown> {
+  private async sendRequest(method: string, params?: unknown, timeoutMs?: number): Promise<unknown> {
     if (!this.worker || !this.isReady) {
       throw new Error('Not connected to database');
     }
@@ -973,7 +994,7 @@ export class DBEngine extends EventEmitter {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id);
         reject(new Error('Request timeout'));
-      }, 300000); // 300秒のタイムアウト（プロセス分離モード考慮）
+      }, timeoutMs ?? 300000);
 
       this.worker!.stdin?.write(JSON.stringify(request) + '\n');
 
@@ -1210,6 +1231,10 @@ export class DBEngine extends EventEmitter {
     return await this.sendRequest('releaseWriter', {
       writer_id: params.writerId,
     }) as { success: boolean };
+  }
+
+  async repairTables(): Promise<RepairTablesResponse> {
+    return await this.sendRequest('repairTables', undefined, 600000) as RepairTablesResponse;
   }
 }
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -22,6 +22,7 @@ import {
   registerIndexStatusTool,
   registerListRelatedProjectsTool,
   registerAddRelatedProjectTool,
+  registerMaintenanceRepairTool,
   type RegisteredTool,
 } from './tools/index.js';
 import { registerResources } from './resources/index.js';
@@ -98,6 +99,7 @@ interface ToolHandles {
   indexStatus: RegisteredTool;
   listRelatedProjects: RegisteredTool;
   addRelatedProject: RegisteredTool;
+  maintenanceRepair: RegisteredTool;
 }
 
 /**
@@ -124,6 +126,7 @@ function updateToolAvailability(_state: SystemState, handles: ToolHandles): void
   handles.indexStatus.enable();
   handles.listRelatedProjects.enable();
   handles.addRelatedProject.enable();
+  handles.maintenanceRepair.enable();
   debugLog('All tools enabled (state check delegated to each tool)');
 }
 
@@ -225,7 +228,13 @@ async function main() {
   const serverManager = new ServerManager();
 
   // ツール登録コンテキスト
-  const context = { server, systemState, refreshSystemState, serverManager };
+  const context = {
+    server,
+    systemState,
+    refreshSystemState,
+    serverManager,
+    getDbEngine: () => serviceInstances?.dbEngine ?? null,
+  };
 
   // リソース登録
   registerResources(server);
@@ -241,6 +250,7 @@ async function main() {
     indexStatus: registerIndexStatusTool(context),
     listRelatedProjects: registerListRelatedProjectsTool(context),
     addRelatedProject: registerAddRelatedProjectTool(context),
+    maintenanceRepair: registerMaintenanceRepairTool(context),
   };
 
   // 初期状態に応じてツールの有効/無効を設定

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -13,5 +13,6 @@ export { registerInitTool } from './init.js';
 export { registerSystemStatusTool } from './system-status.js';
 export { registerListRelatedProjectsTool } from './list-related-projects.js';
 export { registerAddRelatedProjectTool } from './add-related-project.js';
+export { registerMaintenanceRepairTool } from './maintenance-repair.js';
 
 export type { ToolRegistrationContext, RegisteredTool } from './types.js';

--- a/packages/mcp-server/src/tools/maintenance-repair.ts
+++ b/packages/mcp-server/src/tools/maintenance-repair.ts
@@ -1,0 +1,85 @@
+/**
+ * maintenance_repair ツール
+ * LanceDBテーブルの破損を検出・修復する
+ */
+
+import * as path from 'path';
+import { DBEngine } from '@search-docs/db-engine';
+import { getStateErrorMessage } from '../state.js';
+import type { ToolRegistrationContext, RegisteredTool } from './types.js';
+import type { RepairTablesResponse } from '@search-docs/db-engine';
+
+function formatRepairResult(response: RepairTablesResponse): string {
+  let text = '🔧 テーブル修復結果\n\n';
+
+  for (const [tableName, result] of Object.entries(response.tables)) {
+    const icon = result.status === 'ok' ? '✓' : '⚠';
+    text += `  ${icon} ${tableName}: ${result.status}`;
+    if (result.action) {
+      text += ` → ${result.action}`;
+    }
+    if (result.error) {
+      text += `\n    エラー: ${result.error}`;
+    }
+    text += '\n';
+  }
+
+  if (response.initTablesError) {
+    text += `\n❌ テーブル再初期化エラー: ${response.initTablesError}\n`;
+  }
+
+  if (response.createdCount) {
+    text += `\n${response.createdCount}個のテーブルを新規作成しました。\n`;
+  }
+
+  if (response.repairedCount > 0) {
+    text += `${response.repairedCount}個の破損テーブルを修復しました。\n`;
+    text += 'インデックスデータが失われているため、再インデックスが必要です。\n';
+    text += '→ CLIの場合: search-docs index rebuild --force\n';
+  } else if (!response.createdCount) {
+    text += '\n全テーブル正常です。修復の必要はありません。\n';
+  }
+
+  return text;
+}
+
+export function registerMaintenanceRepairTool(context: ToolRegistrationContext): RegisteredTool {
+  const { server, systemState } = context;
+
+  return server.registerTool(
+    'maintenance_repair',
+    {
+      description:
+        'LanceDBテーブルの破損を検出し、自動修復します。破損テーブルはdrop→再作成されます。修復後は再インデックス（index rebuild）が必要です。',
+      inputSchema: {},
+    },
+    async () => {
+      if (systemState.state !== 'RUNNING') {
+        throw new Error(getStateErrorMessage(systemState.state, 'テーブル修復'));
+      }
+
+      const dbEngine = context.getDbEngine?.();
+      if (dbEngine) {
+        const result = await dbEngine.repairTables();
+        const text = formatRepairResult(result);
+        return { content: [{ type: 'text' as const, text }] };
+      }
+
+      // serviceInstances が null（DB破損でサービス作成失敗時）のフォールバック
+      if (!systemState.config) {
+        throw new Error('設定が読み込めません。');
+      }
+
+      const dbPath = path.resolve(systemState.projectRoot, systemState.config.storage.indexPath);
+      const fallbackEngine = new DBEngine({ dbPath, readOnly: false });
+      try {
+        await fallbackEngine.connect({ skipInitModel: true });
+        const result = await fallbackEngine.repairTables();
+        const text = formatRepairResult(result);
+        return { content: [{ type: 'text' as const, text }] };
+      } finally {
+        fallbackEngine.disconnect();
+      }
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/types.ts
+++ b/packages/mcp-server/src/tools/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { DBEngine } from '@search-docs/db-engine';
 import type { SystemStateInfo } from '../state.js';
 import type { ServerManager } from '../server-manager.js';
 
@@ -24,4 +25,6 @@ export interface ToolRegistrationContext {
   refreshSystemState: () => Promise<void>;
   /** サーバマネージャー（複数プロジェクト管理用） */
   serverManager: ServerManager;
+  /** DBEngineインスタンスの取得（メンテナンス操作用） */
+  getDbEngine?: () => DBEngine | null;
 }

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../types" },
     { "path": "../config" },
-    { "path": "../client" }
+    { "path": "../client" },
+    { "path": "../db-engine" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@search-docs/config':
         specifier: workspace:*
         version: link:../config
+      '@search-docs/db-engine':
+        specifier: workspace:*
+        version: link:../db-engine
       '@search-docs/server':
         specifier: workspace:*
         version: link:../server


### PR DESCRIPTION
## Summary

- LanceDBのデータファイル破損時にテーブルを自動検出・修復するメンテナンス機能を追加
- MCP ツール（`maintenance_repair`）と CLI コマンド（`search-docs maintenance repair`）の両方から利用可能
- 各テーブルの健全性チェック → 破損テーブルのみ drop → 再作成の安全なフロー

## 変更内容

| レイヤー | 変更 |
|---------|------|
| Python worker | `repair_tables()` メソッド追加。`count_rows()` で健全性チェック、`table_names()` のエラーハンドリング |
| TypeScript DBEngine | `repairTables()` メソッド追加（600秒タイムアウト）、`connect({ skipInitModel })` オプション追加 |
| MCP Server | `maintenance_repair` ツール追加。DB破損でサービス作成失敗時はDBEngineを直接作成するフォールバック |
| CLI | `search-docs maintenance repair` コマンド追加。embedding server 不要（`skipInitModel`） |

## 背景

LanceDBのデータファイルが部分的に欠損するとIOエラーが発生し、サーバが正常に動作しなくなる。LanceDBには直接的な修復APIがないため、破損テーブルの drop → 再作成が唯一の復旧手段。修復後は `index rebuild --force` で再インデックスが必要。

## Test plan

- [x] `pnpm build` パス
- [x] `pnpm lint` パス
- [ ] `.search-docs/index/` 内の `.lance` ファイルを削除し、`search-docs maintenance repair` で復旧を確認
- [ ] MCP ツール `maintenance_repair` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)