### PR TITLE
feat: index purge + MCPサーバ停止プロセス改善

### DIFF
--- a/packages/cli/src/commands/index/purge.ts
+++ b/packages/cli/src/commands/index/purge.ts
@@ -28,7 +28,7 @@ export async function executeIndexPurge(
     }
 
     console.log(`インデックスを削除します: ${indexPath}`);
-    fs.rmSync(indexPath, { recursive: true });
+    fs.rmSync(indexPath, { recursive: true, force: true });
     console.log('インデックスを削除しました。');
     console.log('再構築するには: search-docs index rebuild');
   } catch (error) {

--- a/packages/cli/src/commands/index/purge.ts
+++ b/packages/cli/src/commands/index/purge.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ConfigLoader } from '@search-docs/config';
+
+export interface IndexPurgeOptions {
+  config?: string;
+}
+
+export async function executeIndexPurge(
+  options: IndexPurgeOptions
+): Promise<void> {
+  try {
+    const { config, projectRoot } = await ConfigLoader.resolve({
+      cwd: process.cwd(),
+      configPath: options.config,
+    });
+
+    if (!config) {
+      console.error('設定ファイルが見つかりません。先に search-docs config init を実行してください。');
+      process.exit(1);
+    }
+
+    const indexPath = path.resolve(projectRoot, config.storage.indexPath);
+
+    if (!fs.existsSync(indexPath)) {
+      console.log(`インデックスディレクトリが存在しません: ${indexPath}`);
+      return;
+    }
+
+    console.log(`インデックスを削除します: ${indexPath}`);
+    fs.rmSync(indexPath, { recursive: true });
+    console.log('インデックスを削除しました。');
+    console.log('再構築するには: search-docs index rebuild');
+  } catch (error) {
+    console.error('Error:', (error as Error).message);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -165,6 +165,14 @@ indexCmd
   });
 
 indexCmd
+  .command('purge')
+  .description('インデックスファイルを削除')
+  .action(async () => {
+    const { executeIndexPurge } = await import('./commands/index/purge.js');
+    await executeIndexPurge({ config: globalConfigPath });
+  });
+
+indexCmd
   .command('status')
   .description('インデックスのステータスを確認')
   .option('--server <url>', 'サーバURL')

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -23,6 +23,7 @@ import {
   registerListRelatedProjectsTool,
   registerAddRelatedProjectTool,
   registerMaintenanceRepairTool,
+  registerIndexPurgeTool,
   type RegisteredTool,
 } from './tools/index.js';
 import { registerResources } from './resources/index.js';
@@ -100,6 +101,7 @@ interface ToolHandles {
   listRelatedProjects: RegisteredTool;
   addRelatedProject: RegisteredTool;
   maintenanceRepair: RegisteredTool;
+  indexPurge: RegisteredTool;
 }
 
 /**
@@ -127,6 +129,7 @@ function updateToolAvailability(_state: SystemState, handles: ToolHandles): void
   handles.listRelatedProjects.enable();
   handles.addRelatedProject.enable();
   handles.maintenanceRepair.enable();
+  handles.indexPurge.enable();
   debugLog('All tools enabled (state check delegated to each tool)');
 }
 
@@ -251,6 +254,7 @@ async function main() {
     listRelatedProjects: registerListRelatedProjectsTool(context),
     addRelatedProject: registerAddRelatedProjectTool(context),
     maintenanceRepair: registerMaintenanceRepairTool(context),
+    indexPurge: registerIndexPurgeTool(context),
   };
 
   // 初期状態に応じてツールの有効/無効を設定

--- a/packages/mcp-server/src/tools/index-purge.ts
+++ b/packages/mcp-server/src/tools/index-purge.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { getStateErrorMessage } from '../state.js';
+import type { ToolRegistrationContext, RegisteredTool } from './types.js';
+
+export function registerIndexPurgeTool(context: ToolRegistrationContext): RegisteredTool {
+  const { server, systemState } = context;
+
+  return server.registerTool(
+    'index_purge',
+    {
+      description:
+        'インデックスファイルを全削除します。壊れたインデックスを廃棄して再構築する場合に使います。',
+      inputSchema: {},
+    },
+    async () => {
+      if (systemState.state === 'NOT_CONFIGURED') {
+        throw new Error(getStateErrorMessage(systemState.state, 'インデックス削除'));
+      }
+
+      if (!systemState.config) {
+        throw new Error('設定が読み込めません。');
+      }
+
+      const indexPath = path.resolve(systemState.projectRoot, systemState.config.storage.indexPath);
+
+      try {
+        await fs.access(indexPath);
+      } catch {
+        return {
+          content: [{ type: 'text' as const, text: 'インデックスディレクトリが存在しません。削除の必要はありません。' }],
+        };
+      }
+
+      await fs.rm(indexPath, { recursive: true });
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `インデックスを削除しました: ${indexPath}\n再構築するには index rebuild を実行してください。`,
+        }],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/index-purge.ts
+++ b/packages/mcp-server/src/tools/index-purge.ts
@@ -32,7 +32,9 @@ export function registerIndexPurgeTool(context: ToolRegistrationContext): Regist
         };
       }
 
-      await fs.rm(indexPath, { recursive: true });
+      await fs.rm(indexPath, { recursive: true, force: true });
+
+      await context.refreshSystemState();
 
       return {
         content: [{

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -14,5 +14,6 @@ export { registerSystemStatusTool } from './system-status.js';
 export { registerListRelatedProjectsTool } from './list-related-projects.js';
 export { registerAddRelatedProjectTool } from './add-related-project.js';
 export { registerMaintenanceRepairTool } from './maintenance-repair.js';
+export { registerIndexPurgeTool } from './index-purge.js';
 
 export type { ToolRegistrationContext, RegisteredTool } from './types.js';

--- a/prompts/tasks/task47.purge-index.v1.md
+++ b/prompts/tasks/task47.purge-index.v1.md
@@ -1,0 +1,27 @@
+# task47: インデックスファイル削除（purge）機能
+
+## 目的
+
+壊れたインデックスを廃棄して再構築するためのコマンドを追加する。
+repair（部分修復）とは異なり、インデックスディレクトリごと削除する機能。
+
+## 方針
+
+- `storage.indexPath`（デフォルト: `.search-docs/index`）ディレクトリを削除
+- CLI: `maintenance purge` コマンド追加（repairと並列）
+- MCP: `maintenance_purge` ツール追加
+- DBEngine不要（ファイルシステム操作のみ）
+
+## 変更箇所
+
+1. `packages/cli/src/commands/index/purge.ts` — 新規
+2. `packages/cli/src/index.ts` — `index purge` サブコマンド追加
+3. `packages/mcp-server/src/tools/index-purge.ts` — 新規（`index_purge` ツール）
+4. `packages/mcp-server/src/tools/index.ts` — export追加
+5. `packages/mcp-server/src/server.ts` — ツール登録
+
+## 進捗
+
+- [x] CLI実装（`index purge`）
+- [x] MCP実装（`index_purge`）
+- [x] ビルド・lint確認


### PR DESCRIPTION
## Summary

- `index purge` コマンド追加（CLI + MCPツール）: 壊れたインデックスを廃棄するためのコマンド
- MCPサーバの停止プロセスを改善: シグナル受信時に即座に終了するように

### index purge
- CLI: `search-docs index purge`
- MCP: `index_purge` ツール
- DBEngine不要、ファイルシステム操作のみ

### 停止プロセス改善
- FileStorageをatomic write（tmp→rename）に変更し、kill時のデータ破損を防止
- WatcherProcess/EmbeddingServerに`shutdown()`メソッド追加（即座に停止、待機なし）
- `stopService()`を同期関数に変更（mastershipリリース・子プロセス終了待ちを廃止）
- シグナルハンドラを`process.exit()`付きに変更、全体タイムアウト3秒

### 設計判断
- LanceDBはMVCCで書き込み途中の中断に耐える → 即kill可能
- Writer mastershipは120秒で自動復旧 → 解放不要
- 子プロセスは親が死ねばOSが回収 → PID管理・終了待ち不要
- **唯一壊れるFileStorage**をatomic writeで保護 → これで即kill安全

## Test plan

- [ ] `search-docs index purge` でインデックス削除確認
- [ ] MCP `index_purge` ツールで同様の動作確認
- [ ] MCPサーバにSIGTERMを送って即座に終了することを確認
- [ ] `pnpm build` / `pnpm lint` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)