### PR TITLE
fix: MCPサーバの停止プロセスを改善

### DIFF
--- a/.changeset/index-purge-and-shutdown.md
+++ b/.changeset/index-purge-and-shutdown.md
@@ -1,0 +1,11 @@
+---
+"@search-docs/mcp-server": patch
+"@search-docs/server": patch
+"@search-docs/storage": patch
+---
+
+MCPサーバ停止プロセス改善
+
+- FileStorageをatomic write（tmp→rename）に変更し、kill時のデータ破損を防止
+- MCPサーバのシグナルハンドラを改善し、即座に終了するように
+- stopServiceを同期化（mastershipリリース・子プロセス終了待ちを廃止）

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -200,7 +200,7 @@ async function main() {
     // 既存サービスを停止
     if (serviceInstances) {
       debugLog('Stopping existing service before refresh...');
-      await stopService(serviceInstances);
+      stopService(serviceInstances);
       serviceInstances = null;
     }
 
@@ -261,16 +261,23 @@ async function main() {
   updateToolAvailability(systemState.state, toolHandles);
 
   // プロセス終了時のクリーンアップ
-  const cleanup = async () => {
-    debugLog('Cleaning up...');
+  const shutdown = () => {
+    debugLog('Shutdown signal received');
+    // 全体タイムアウト: 3秒で強制終了
+    setTimeout(() => {
+      debugLog('Shutdown timeout, forcing exit');
+      process.exit(1);
+    }, 3000).unref();
+
     if (serviceInstances) {
-      await stopService(serviceInstances);
+      stopService(serviceInstances);
       serviceInstances = null;
     }
+    process.exit(0);
   };
 
-  process.on('SIGINT', () => void cleanup());
-  process.on('SIGTERM', () => void cleanup());
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 
   // サーバの起動
   const transport = new StdioServerTransport();

--- a/packages/mcp-server/src/state.ts
+++ b/packages/mcp-server/src/state.ts
@@ -139,14 +139,30 @@ export async function createService(
 }
 
 /**
- * サービスインスタンスを停止
+ * サービスインスタンスを停止（即座に完了する）
+ *
+ * WatcherProcess（IndexWorker）のタイマーを停止し、新規処理を防ぐ。
+ * 子プロセス（Python worker, Embedding server）にSIGTERMを送信する。
+ * 子プロセスは親プロセス終了時にOSが回収するため、終了待ちは不要。
+ *
+ * FileStorageはatomic write（tmp→rename）のため、書き込み途中でも壊れない。
+ * LanceDBはMVCCのため、書き込み途中でも壊れない。
+ * Writer mastershipは120秒で自動復旧するため、明示的な解放は不要。
  *
  * @param instances - サービスインスタンス群
  */
-export async function stopService(instances: ServiceInstances): Promise<void> {
-  await instances.watcherProcess.stop();
+export function stopService(instances: ServiceInstances): void {
+  // 1. WatcherProcessを停止（タイマー・ワーカー即停止、mastershipは解放しない）
+  instances.watcherProcess.shutdown();
+
+  // 2. 読み取り専用サービスを停止
   instances.service.stop();
-  await instances.embeddingServer.stop();
+
+  // 3. DBEngineを切断（Python workerをkill）
+  instances.dbEngine.disconnect();
+
+  // 4. EmbeddingServerを停止（子プロセスにSIGTERM）
+  instances.embeddingServer.shutdown();
 }
 
 /**

--- a/packages/server/src/embedding/embedding-server-process.ts
+++ b/packages/server/src/embedding/embedding-server-process.ts
@@ -79,6 +79,17 @@ export class EmbeddingServerProcess {
     }
   }
 
+  /**
+   * 即座に停止する（シグナルハンドラ用）
+   * 子プロセスは親プロセス終了時にOSが回収するため、終了待ちは不要。
+   */
+  shutdown(): void {
+    if (this.process) {
+      this.process.kill('SIGTERM');
+      this.process = null;
+    }
+  }
+
   getUrl(): string {
     if (!this.url) {
       throw new Error('[EmbeddingServer] Not started yet');

--- a/packages/server/src/watcher/watcher-process.ts
+++ b/packages/server/src/watcher/watcher-process.ts
@@ -132,6 +132,26 @@ export class WatcherProcess {
   }
 
   /**
+   * 即座に停止する（シグナルハンドラ用）
+   *
+   * mastershipの解放は行わない（120秒で自動復旧する）。
+   * タイマーとワーカーを即座に停止し、新規処理を防ぐ。
+   */
+  shutdown(): void {
+    console.log('[WatcherProcess] Shutdown...');
+    this.stopHeartbeat();
+    this.stopMasterCheck();
+
+    if (this.indexWorker) {
+      this.indexWorker.stop();
+    }
+    if (this.watcher?.isRunning()) {
+      // fire-and-forget: watcher.stop()はawaitしない
+      void this.watcher.stop();
+    }
+  }
+
+  /**
    * Master確認とclaim試行
    */
   private async checkAndClaimMaster(): Promise<void> {

--- a/packages/storage/src/file-storage.ts
+++ b/packages/storage/src/file-storage.ts
@@ -43,12 +43,10 @@ export class FileStorage implements DocumentStorage {
       },
     };
 
-    // JSON形式で保存
-    await fs.writeFile(
-      filePath,
-      JSON.stringify(docWithHash, null, 2),
-      'utf-8'
-    );
+    // Atomic write: tmp → rename でデータ破損を防止
+    const tmpPath = filePath + '.tmp';
+    await fs.writeFile(tmpPath, JSON.stringify(docWithHash, null, 2), 'utf-8');
+    await fs.rename(tmpPath, filePath);
   }
 
   /**

--- a/prompts/tasks/task48.graceful-shutdown-design.v1.md
+++ b/prompts/tasks/task48.graceful-shutdown-design.v1.md
@@ -1,0 +1,91 @@
+# task48: MCPサーバの安全な停止プロセス設計
+
+## 背景
+
+MCPサーバのkillシグナルに対する応答性が悪い。
+原因は「停止プロセス」が設計されておらず、「終わるのを待つ」消極的な実装になっていること。
+
+## 急に殺して何が壊れるか
+
+調査の結果、**ほとんどのものは即killしても壊れない**。
+
+| 項目 | 壊れるか | 理由 |
+|---|---|---|
+| LanceDB | 壊れない | MVCCで不完全な書き込みは破棄される |
+| writer heartbeat | 壊れない | 120秒後に期限切れで自動復旧 |
+| PIDファイル | 壊れない | staleチェックがある |
+| Embeddingサーバ | 壊れない | healthCheckで再利用される |
+| FileWatcher | 壊れない | ロックなし、プロセス終了で解放 |
+| **DocumentStorage** | **壊れる** | `fs.writeFile()` 途中で死ぬと不完全なJSONが残る |
+
+### 唯一の問題: FileStorage.save()の非atomic書き込み
+
+```typescript
+// packages/storage/src/file-storage.ts:47
+await fs.writeFile(filePath, JSON.stringify(docWithHash, null, 2), 'utf-8');
+```
+
+途中でkillされると壊れたJSONが残り、次回 `JSON.parse()` で失敗する。
+これはgraceful shutdown以前に、**atomic write（tmp→rename）で根本解決すべき問題**。
+
+### FileStorageに書き込むのは誰か
+
+IndexWorker（WatcherProcess内）のみ。直接ではなく、IndexWorker.processRequest() → storage.get() で読む側。
+
+実際の書き込みパスを確認:
+- `storage.save()` を呼んでいるのはWatcherProcessの中のファイル変更検知 → indexRequest作成のフロー
+- **IndexWorker自体はstorageに書き込まない**（LanceDBに書き込む）
+
+→ WatcherProcessのファイル変更検知フロー内で `storage.save()` が呼ばれる箇所がatomic writeの対象。
+
+## 停止プロセスの設計
+
+### 前提
+
+- 子プロセス（Python worker, Embedding server）は親が死ねばinitに回収される。PID管理は不要
+- 親プロセスのPIDファイルはJSON-RPCサーバのみ使用（既存の仕組みで十分）
+- LanceDBはMVCCで書き込み途中の中断に耐える
+- **守るべきものはFileStorageの書き込みだけ**
+
+### 原則
+
+1. **FileStorageのatomic writeを実装する** — これが入れば即killでも壊れない
+2. **停止は速やかに行う** — 守るべきものがないなら、さっさと死ぬ
+3. **全体のタイムアウトを設ける** — 何かが詰まっても必ず終了する
+
+### 停止シーケンス
+
+```
+シグナル受信 (SIGINT/SIGTERM)
+  │
+  ├─ 1. IndexWorkerを停止（新規処理を開始しない）
+  │     isRunning = false, clearInterval
+  │
+  ├─ 2. 処理中の書き込みがあれば完了を待つ（最大2秒）
+  │     IndexWorker.isProcessing を監視
+  │     ※ FileStorageがatomic writeなら、この待機自体が不要になる
+  │
+  ├─ 3. 残りのリソースを解放
+  │     タイマー全クリア、FileWatcher停止、子プロセスkill
+  │
+  └─ process.exit()
+
+全体タイムアウト: 3秒。超過したらprocess.exit(1)。
+```
+
+### 実装方針
+
+**Phase 1: FileStorageのatomic write**
+- `fs.writeFile(path, data)` → `fs.writeFile(path + '.tmp', data)` + `fs.rename(path + '.tmp', path)`
+- rename はPOSIXでatomic。途中でkillされても `.tmp` ファイルが残るだけで既存データは壊れない
+- `.tmp` ファイルは次回起動時に無視する（or 削除する）
+
+**Phase 2: シグナルハンドラの改善**
+- `void cleanup()` → `await cleanup()` + `process.exit()`
+- 全体タイムアウト: `setTimeout(() => process.exit(1), 3000)`
+- IndexWorkerの処理完了を待つ（atomic write後はこの待機を省略可能）
+
+**Phase 3: stopServiceの簡素化**
+- mastershipリリース（releaseWriter）: 不要にする。120秒で自動復旧する
+- 子プロセスの停止: `worker.kill()` で十分（親が死ねば子も回収される）
+- EmbeddingServerの5秒タイムアウト: 不要にする


### PR DESCRIPTION
## Summary

- FileStorageをatomic write（tmp→rename）に変更し、kill時のデータ破損を防止
- WatcherProcess/EmbeddingServerに`shutdown()`メソッド追加（即座に停止、待機なし）
- `stopService()`を同期関数に変更（mastershipリリース・子プロセス終了待ちを廃止）
- シグナルハンドラを`process.exit()`付きに変更、全体タイムアウト3秒

### 設計判断

「急に殺して何が壊れるか」を調査した結果、壊れるのはFileStorageの非atomic書き込みのみ。

- LanceDBはMVCCで書き込み途中の中断に耐える
- Writer mastershipは120秒で自動復旧する
- 子プロセスは親が死ねばOSが回収する

FileStorageをatomic writeにすることで、即kill安全になった。
停止プロセスは「終わるのを待つ」のではなく「さっさと死ぬ」設計に。

## Test plan

- [ ] MCPサーバにSIGTERMを送って即座に終了することを確認
- [ ] `pnpm build` / `pnpm lint` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)